### PR TITLE
Add `main_window_events` + Cycle through channels when adding to MDA

### DIFF
--- a/micromanager_gui/_signals.py
+++ b/micromanager_gui/_signals.py
@@ -1,0 +1,9 @@
+from qtpy.QtCore import QObject, Signal
+
+__all__ = [
+    "main_window_events",
+]
+
+
+class main_window_events(QObject):
+    availableChannelsChanged = Signal(tuple)

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -16,6 +16,7 @@ from qtpy.QtGui import QColor, QIcon
 from ._camera_roi import CameraROI
 from ._illumination import IlluminationDialog
 from ._saving import save_sequence
+from ._signals import main_window_events
 from ._util import (
     SelectDeviceFromCombobox,
     blockSignals,
@@ -105,6 +106,7 @@ class MainWindow(QtW.QWidget, _MainUI):
         super().__init__()
         self.setup_ui()
 
+        self.events = main_window_events()
         self.viewer = viewer
         self.streaming_timer = None
 
@@ -123,7 +125,7 @@ class MainWindow(QtW.QWidget, _MainUI):
             )
 
         # tab widgets
-        self.mda = MultiDWidget(self._mmc)
+        self.mda = MultiDWidget(self._mmc, self.events)
         self.explorer = ExploreSample(self.viewer, self._mmc)
         self.tabWidget.addTab(self.mda, "Multi-D Acquisition")
         self.tabWidget.addTab(self.explorer, "Sample Explorer")
@@ -445,6 +447,7 @@ class MainWindow(QtW.QWidget, _MainUI):
             self.snap_channel_comboBox.setCurrentText(
                 self._mmc.getCurrentConfig(channel_group)
             )
+            self.events.availableChannelsChanged.emit(channel_list)
 
     def _refresh_positions(self):
         if self._mmc.getXYStageDevice():

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -447,7 +447,7 @@ class MainWindow(QtW.QWidget, _MainUI):
             self.snap_channel_comboBox.setCurrentText(
                 self._mmc.getCurrentConfig(channel_group)
             )
-            self.events.availableChannelsChanged.emit(channel_list)
+            self.events.availableChannelsChanged.emit(tuple(channel_list))
 
     def _refresh_positions(self):
         if self._mmc.getXYStageDevice():


### PR DESCRIPTION
1. Make events for main window
Handy for letting things like the mda widget keep track of overall state

2. cycle through channels when adding
previously each channel would be added with whatever the first channel was. Now we do a naive cycling through them. I explored keeping track of what had been added and removed but seems to be more trouble than it was worth.

![Peek 2022-02-11 15-42](https://user-images.githubusercontent.com/10111092/153667261-16560211-597a-4b8f-9ed9-a7d2d91e7869.gif)
