### PR TITLE
fix: Make zarr a requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,13 +34,13 @@ install_requires =
     superqt >=0.3.1
     fonticon-materialdesignicons6
     tifffile
+    zarr
 
 [options.extras_require]
 testing =
     pytest
     pytest-qt
     pytest-cov
-    zarr
 pyqt5 =
     PyQt5
 pyside2 =


### PR DESCRIPTION
This got missed in https://github.com/pymmcore-plus/napari-micromanager/pull/145