### PR TITLE
feat: add napari-micromanager command prompt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ Source = "https://github.com/pymmcore-plus/napari-micromanager"
 Tracker = "https://github.com/pymmcore-plus/napari-micromanager/issues"
 # Documentation = "https://pymmcore-plus.github.io/napari-micromanager"
 
+[project.scripts]
+napari-micromanager = "napari_micromanager.__main__:main"
+
 [project.entry-points."napari.manifest"]
 "napari-micromanager" = "napari_micromanager:napari.yaml"
 

--- a/src/napari_micromanager/__main__.py
+++ b/src/napari_micromanager/__main__.py
@@ -4,9 +4,9 @@ def main() -> None:
 
     viewer = napari.Viewer()
     win = MainWindow(viewer)
-    viewer.window.add_dock_widget(
-        win, name="MicroManager", area="top"
-    )._close_btn = False
+    dw = viewer.window.add_dock_widget(win, name="MicroManager", area="top")
+    if hasattr(dw, "_close_btn"):
+        dw._close_btn = False
     napari.run()
 
 

--- a/src/napari_micromanager/__main__.py
+++ b/src/napari_micromanager/__main__.py
@@ -1,7 +1,14 @@
-import napari
-from napari_micromanager.main_window import MainWindow
+def main() -> None:
+    import napari
+    from napari_micromanager.main_window import MainWindow
 
-viewer = napari.Viewer()
-win = MainWindow(viewer)
-viewer.window.add_dock_widget(win, name="MicroManager", area="top")._close_btn = False
-napari.run()
+    viewer = napari.Viewer()
+    win = MainWindow(viewer)
+    viewer.window.add_dock_widget(
+        win, name="MicroManager", area="top"
+    )._close_btn = False
+    napari.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,11 @@
+from unittest.mock import patch
+
+from napari_micromanager.__main__ import main
+
+
+def test_cli_main() -> None:
+    with patch("napari.run") as mock_run:
+        with patch("qtpy.QtWidgets.QMainWindow.show") as mock_show:
+            main()
+    mock_run.assert_called_once()
+    mock_show.assert_called_once()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,8 +4,15 @@ from napari_micromanager.__main__ import main
 
 
 def test_cli_main() -> None:
+    import napari
+    from napari.qt import QtViewer
+
     with patch("napari.run") as mock_run:
         with patch("qtpy.QtWidgets.QMainWindow.show") as mock_show:
             main()
     mock_run.assert_called_once()
     mock_show.assert_called_once()
+
+    # this is to prevent a leaked widget error in the NEXT test
+    napari.current_viewer().close()
+    QtViewer._instances.clear()


### PR DESCRIPTION
adds a `napari-micromanager` command (same as `python -m napari_micromanager`)