### PR TITLE
Remove seq meta

### DIFF
--- a/src/napari_micromanager/__init__.py
+++ b/src/napari_micromanager/__init__.py
@@ -8,7 +8,4 @@ except PackageNotFoundError:
 
 from .main_window import MainWindow
 
-__all__ = [
-    "__version__",
-    "MainWindow",
-]
+__all__ = ["__version__", "MainWindow"]

--- a/src/napari_micromanager/_gui_objects/_mda_widget.py
+++ b/src/napari_micromanager/_gui_objects/_mda_widget.py
@@ -18,7 +18,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from .._mda_meta import SEQUENCE_META, SequenceMeta
+from .._mda_meta import SEQUENCE_META_KEY, SequenceMeta
 
 
 class MultiDWidget(MDAWidget):
@@ -136,9 +136,8 @@ class MultiDWidget(MDAWidget):
     def _on_run_clicked(self) -> None:
         """Run the MDA sequence experiment."""
         # construct a `useq.MDASequence` object from the values inserted in the widget
-        experiment = self.get_state()
-
-        SEQUENCE_META[experiment] = SequenceMeta(
+        sequence = self.get_state()
+        sequence.metadata[SEQUENCE_META_KEY] = SequenceMeta(
             mode="mda",
             split_channels=self.checkBox_split_channels.isChecked(),
             should_save=self.save_groupbox.isChecked(),
@@ -149,5 +148,5 @@ class MultiDWidget(MDAWidget):
         )
 
         # run the MDA experiment asynchronously
-        self._mmc.run_mda(experiment)  # run the MDA experiment asynchronously
+        self._mmc.run_mda(sequence)
         return

--- a/src/napari_micromanager/_gui_objects/_sample_explorer_widget.py
+++ b/src/napari_micromanager/_gui_objects/_sample_explorer_widget.py
@@ -17,7 +17,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from .._mda_meta import SEQUENCE_META, SequenceMeta
+from .._mda_meta import SEQUENCE_META_KEY, SequenceMeta
 
 
 class SampleExplorer(SampleExplorerWidget):
@@ -169,9 +169,9 @@ class SampleExplorer(SampleExplorerWidget):
     def _start_scan(self) -> None:
         """Run the MDA sequence experiment."""
         # construct a `useq.MDASequence` object from the values inserted in the widget
-        experiment = self.get_state()
+        sequence = self.get_state()
 
-        SEQUENCE_META[experiment] = SequenceMeta(
+        sequence.metadata[SEQUENCE_META_KEY] = SequenceMeta(
             mode="explorer",
             should_save=self.save_explorer_groupbox.isChecked(),
             file_name=self.fname_explorer_lineEdit.text(),
@@ -184,5 +184,5 @@ class SampleExplorer(SampleExplorerWidget):
         )
 
         # run the MDA experiment asynchronously
-        self._mmc.run_mda(experiment)  # run the MDA experiment asynchronously
+        self._mmc.run_mda(sequence)
         return

--- a/src/napari_micromanager/_mda_meta.py
+++ b/src/napari_micromanager/_mda_meta.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from useq import MDASequence
 
-__all__ = [
-    "SequenceMeta",
-    "SEQUENCE_META",
-]
+__all__ = ["SequenceMeta", "SEQUENCE_META_KEY"]
+
+
+# This is the key in the MDASequence.metadata dict that will contain the
+# SequenceMeta object.
+SEQUENCE_META_KEY = "napari_mm_sequence_meta"
 
 
 @dataclass
@@ -25,6 +26,3 @@ class SequenceMeta:
     explorer_translation_points: list = field(default_factory=list)
     scan_size_r: int = 0
     scan_size_c: int = 0
-
-
-SEQUENCE_META: dict[MDASequence, SequenceMeta] = {}

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from napari_micromanager._gui_objects._sample_explorer_widget import SampleExplorer
-from napari_micromanager._mda_meta import SEQUENCE_META
+from napari_micromanager._mda_meta import SEQUENCE_META_KEY, SequenceMeta
 from napari_micromanager._util import event_indices
 from pymmcore_plus.mda import MDAEngine
 from pymmcore_widgets._zstack_widget import ZRangeAroundSelect
@@ -50,7 +50,7 @@ def test_explorer_main(main_window: MainWindow, qtbot: QtBot):
     @mmc.mda.events.sequenceStarted.connect
     def get_seq(seq: MDASequence):
         nonlocal uid, meta
-        meta = SEQUENCE_META[seq]
+        meta = seq.metadata[SEQUENCE_META_KEY]
         uid = seq.uid
 
     with qtbot.waitSignals(
@@ -65,7 +65,7 @@ def test_explorer_main(main_window: MainWindow, qtbot: QtBot):
     assert mmc.getROI(mmc.getCameraDevice())[-1] == 512
     assert mmc.getROI(mmc.getCameraDevice())[-2] == 512
 
-    assert meta
+    assert isinstance(meta, SequenceMeta)
     assert meta.mode == "explorer"
 
     assert meta.explorer_translation_points == [

--- a/tests/test_multid_widget.py
+++ b/tests/test_multid_widget.py
@@ -78,7 +78,7 @@ def test_saving_mda(
     if C and splitC:
         _mda.checkBox_split_channels.setChecked(True)
 
-    mda: MDASequence = None
+    mda: MDASequence | None = None
 
     mmc = main_window._mmc
     # re-register twice to fully exercise the logic of the update
@@ -96,7 +96,7 @@ def test_saving_mda(
     # make the images non-square
     mmc.setProperty("Camera", "OnCameraCCDYSize", 500)
 
-    with qtbot.waitSignal(mmc.mda.events.sequenceFinished, timeout=4000):
+    with qtbot.waitSignal(mmc.mda.events.sequenceFinished, timeout=10000):
         _mda.buttons_wdg.run_button.click()
 
     assert mda is not None

--- a/tests/test_multid_widget.py
+++ b/tests/test_multid_widget.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
-from napari_micromanager import _mda_meta
 from napari_micromanager._gui_objects._mda_widget import MultiDWidget
+from napari_micromanager._mda_meta import SEQUENCE_META_KEY, SequenceMeta
 from napari_micromanager._util import event_indices
 from napari_micromanager.main_window import MainWindow
 from pymmcore_plus.mda import MDAEngine
@@ -25,9 +25,8 @@ def test_main_window_mda(main_window: MainWindow):
         time_plan={"loops": 4, "interval": 0.1},
         z_plan={"range": 3, "step": 1},
         channels=["DAPI", "FITC"],
+        metadata={SEQUENCE_META_KEY: SequenceMeta(mode="mda")},
     )
-
-    _mda_meta.SEQUENCE_META[mda] = _mda_meta.SequenceMeta(mode="mda")
 
     mmc = main_window._mmc
 
@@ -130,9 +129,8 @@ def test_script_initiated_mda(main_window: MainWindow, qtbot: QtBot):
         z_plan={"range": 4, "step": 5},
         axis_order="tpcz",
         stage_positions=[(222, 1, 1), (111, 0, 0)],
+        metadata={SEQUENCE_META_KEY: SequenceMeta(mode="mda")},
     )
-
-    _mda_meta.SEQUENCE_META[sequence] = _mda_meta.SequenceMeta(mode="mda")
 
     with qtbot.waitSignal(mmc.mda.events.sequenceFinished, timeout=2000):
         mmc.run_mda(sequence)


### PR DESCRIPTION
this PR removes the `SEQUENCE_META` dict altogether, in favor of putting the metadata in the `MDASequence.metadata` dict which we now have thanks to @ianhi  in https://github.com/pymmcore-plus/useq-schema/pull/35