### PR TITLE
feat: add scale to layers

### DIFF
--- a/src/napari_micromanager/main_window.py
+++ b/src/napari_micromanager/main_window.py
@@ -303,7 +303,6 @@ class MainWindow(MicroManagerToolbar):
             layer.scale = self._get_scale_from_sequence(
                 sequence, layer.data.shape, meta
             )
-            print("#############", layer.scale, layer.data.shape)
 
             # add metadata to layer
             layer.metadata["mode"] = meta.mode
@@ -368,7 +367,7 @@ class MainWindow(MicroManagerToolbar):
         # sourcery skip: use-contextlib-suppress
         try:
             index = sequence.used_axes.index("z")
-            if meta.split_channels and sequence.axis_order == "tpcz":
+            if meta.split_channels and sequence.axis_order in ["tpcz", "ptcz"]:
                 index -= 1
             scale[index] = getattr(sequence.z_plan, "step", 1)
         except ValueError:

--- a/src/napari_micromanager/main_window.py
+++ b/src/napari_micromanager/main_window.py
@@ -4,7 +4,7 @@ import atexit
 import contextlib
 import tempfile
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Tuple
+from typing import TYPE_CHECKING, Any, List
 
 import napari
 import numpy as np
@@ -356,7 +356,7 @@ class MainWindow(MicroManagerToolbar):
 
     def _get_scale_from_sequence(
         self, sequence: MDASequence, layer: napari.layers.Image
-    ) -> Tuple[float, ...]:  # noqa: U006
+    ) -> List[float]:  # noqa: U006
         """Calculate and return the layer scale.
 
         ...using pixel size, layer shape and the MDASequence z info.
@@ -369,7 +369,7 @@ class MainWindow(MicroManagerToolbar):
                 scale[-3] = sequence.z_plan.step
             elif sequence.axis_order.index("z") == 2:
                 scale[-4] = sequence.z_plan.step
-        return tuple(scale)
+        return scale
 
     @ensure_main_thread  # type: ignore [misc]
     def _on_mda_frame(self, image: np.ndarray, event: ActiveMDAEvent) -> None:

--- a/src/napari_micromanager/main_window.py
+++ b/src/napari_micromanager/main_window.py
@@ -355,14 +355,10 @@ class MainWindow(MicroManagerToolbar):
         """
         scale = [1.0] * len(layer_shape)
         scale[-2:] = [self._mmc.getPixelSizeUm()] * 2
-        # sourcery skip: use-contextlib-suppress
-        try:
-            index = sequence.used_axes.index("z")
-            if meta.split_channels and sequence.axis_order in ["tpcz", "ptcz"]:
+        if (index := sequence.used_axes.find("z")) > -1:
+            if meta.split_channels and sequence.used_axes.find("c") < index:
                 index -= 1
             scale[index] = getattr(sequence.z_plan, "step", 1)
-        except ValueError:
-            pass  # z not in used_axes
         return scale
 
     @ensure_main_thread  # type: ignore [misc]

--- a/src/napari_micromanager/main_window.py
+++ b/src/napari_micromanager/main_window.py
@@ -359,7 +359,7 @@ class MainWindow(MicroManagerToolbar):
     ) -> Tuple[float, ...]:  # noqa: U006
         """Calculate and return the layer scale.
 
-        ...using layer shape and the MDASequence z info.
+        ...using pixel size, layer shape and the MDASequence z info.
         """
         scale = [self._mmc.getPixelSizeUm()] * len(layer.data.shape)
         if len(sequence.z_plan) > 1 and isinstance(

--- a/src/napari_micromanager/main_window.py
+++ b/src/napari_micromanager/main_window.py
@@ -360,6 +360,7 @@ class MainWindow(MicroManagerToolbar):
         """
         scale = [1.0] * len(layer.data.shape)
         scale[-2:] = [self._mmc.getPixelSizeUm()] * 2
+        # sourcery skip: use-contextlib-suppress
         try:
             index = sequence.axis_order.index("z")
             if index == 2:
@@ -471,8 +472,6 @@ class MainWindow(MicroManagerToolbar):
         for group in layergroups.values():
             link_layers(group)
 
-        # for a, v in enumerate(im_idx):
-        #     self.viewer.dims.set_point(a, v)
         cs = list(self.viewer.dims.current_step)
         for a, v in enumerate(im_idx):
             cs[a] = v

--- a/src/napari_micromanager/main_window.py
+++ b/src/napari_micromanager/main_window.py
@@ -4,7 +4,7 @@ import atexit
 import contextlib
 import tempfile
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Tuple
 
 import napari
 import numpy as np
@@ -15,7 +15,7 @@ from pymmcore_plus._util import find_micromanager
 from qtpy.QtCore import QTimer
 from qtpy.QtGui import QColor
 from superqt.utils import create_worker, ensure_main_thread
-from useq import MDAEvent, MDASequence
+from useq import MDAEvent, MDASequence, ZAboveBelow, ZRangeAround, ZTopBottom
 
 from . import _mda_meta
 from ._gui_objects._toolbar import MicroManagerToolbar
@@ -115,6 +115,8 @@ class MainWindow(MicroManagerToolbar):
             preview_layer = self.viewer.add_image(data, name="preview")
 
         preview_layer.metadata["mode"] = "preview"
+        preview_layer.scale = (self._mmc.getPixelSizeUm(), self._mmc.getPixelSizeUm())
+        preview_layer.metadata["scale"] = preview_layer.scale
 
         self._update_max_min()
 
@@ -298,11 +300,15 @@ class MainWindow(MicroManagerToolbar):
             layer = self.viewer.add_image(z, name=f"{fname}_{id_}", blending="additive")
             layer.visible = False
 
+            # set layer scale
+            layer.scale = self._get_scale_from_sequence(sequence, layer)
+
             # add metadata to layer
             layer.metadata["mode"] = meta.mode
             layer.metadata["useq_sequence"] = sequence
             layer.metadata["uid"] = sequence.uid
             layer.metadata["ch_id"] = f"{channel}"
+            layer.metadata["scale"] = layer.scale
 
     def _add_explorer_positions_layers(
         self,
@@ -329,12 +335,16 @@ class MainWindow(MicroManagerToolbar):
             layer = self.viewer.add_image(z, name=f"{fname}_{id_}", blending="additive")
             layer.visible = False
 
+            # set layer scale
+            layer.scale = self._get_scale_from_sequence(sequence, layer)
+
             # add metadata to layer
             layer.metadata["mode"] = meta.mode
             layer.metadata["useq_sequence"] = sequence
             layer.metadata["uid"] = sequence.uid
             layer.metadata["grid"] = pos.split("_")[-3]
             layer.metadata["grid_pos"] = pos.split("_")[-2]
+            layer.metadata["scale"] = layer.scale
 
     def _get_defaultdict_layers(self, event: ActiveMDAEvent) -> defaultdict[Any, set]:
         layergroups = defaultdict(set)
@@ -343,6 +353,23 @@ class MainWindow(MicroManagerToolbar):
                 key = lay.metadata.get("grid")[:8]
                 layergroups[key].add(lay)
         return layergroups
+
+    def _get_scale_from_sequence(
+        self, sequence: MDASequence, layer: napari.layers.Image
+    ) -> Tuple[float, ...]:  # noqa: U006
+        """Calculate and return the layer scale.
+
+        ...using layer shape and the MDASequence z info.
+        """
+        scale = [self._mmc.getPixelSizeUm()] * len(layer.data.shape)
+        if len(sequence.z_plan) > 1 and isinstance(
+            sequence.z_plan, (ZTopBottom, ZRangeAround, ZAboveBelow)
+        ):
+            if sequence.axis_order.index("z") == 3:
+                scale[-3] = sequence.z_plan.step
+            elif sequence.axis_order.index("z") == 2:
+                scale[-4] = sequence.z_plan.step
+        return tuple(scale)
 
     @ensure_main_thread  # type: ignore [misc]
     def _on_mda_frame(self, image: np.ndarray, event: ActiveMDAEvent) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def main_window(core: CMMCorePlus, make_napari_viewer):
 
 
 TIME_PLANS = (None, useq.TIntervalLoops(loops=3, interval=0.250))
-Z_PLANS = (None, useq.ZRangeAround(range=3, step=1))
+Z_PLANS = (None, useq.ZRangeAround(range=3, step=0.5))
 CHANNEL_PLANS = (
     (useq.Channel(config="DAPI", exposure=5),),
     (useq.Channel(config="DAPI", exposure=5), useq.Channel(config="Cy5", exposure=5)),

--- a/tests/test_layer_scale.py
+++ b/tests/test_layer_scale.py
@@ -3,67 +3,51 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-from napari_micromanager._gui_objects._mda_widget import MultiDWidget
 from napari_micromanager._mda_meta import SEQUENCE_META_KEY, SequenceMeta
 from napari_micromanager.main_window import MainWindow
-from pymmcore_widgets._zstack_widget import ZRangeAroundSelect
+from useq import MDASequence
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
 
 
 @pytest.mark.parametrize("Z", ["", "withZ"])
-@pytest.mark.parametrize("splitC", ["", "splitC"])
 @pytest.mark.parametrize("C", ["", "withC"])
+@pytest.mark.parametrize("splitC", ["", "splitC"])
 @pytest.mark.parametrize("T", ["", "withT"])
-def test_layer_scale(qtbot: QtBot, main_window: MainWindow, T, C, splitC, Z):
+def test_layer_scale(qtbot: QtBot, main_window: MainWindow, Z, C, splitC, T):
 
     Z_RANGE = 5
     STEP_SIZE = 2
+
     mmc = main_window._mmc
     mmc.setProperty("Objective", "Label", "Nikon 20X Plan Fluor ELWD")
-    main_window._show_dock_widget("MDA")
-    _mda = main_window._dock_widgets["MDA"].widget()
-    assert isinstance(_mda, MultiDWidget)
 
-    _mda.time_groupbox.setChecked(bool(T))
-    _mda.time_groupbox.time_comboBox.setCurrentText("ms")
-    _mda.time_groupbox.timepoints_spinBox.setValue(3)
-    _mda.time_groupbox.interval_spinBox.setValue(250)
+    for order in ["tpcz", "tpzc"]:
+        sequence = MDASequence(
+            axis_order=order,
+            channels=["DAPI", "Cy5"] if (C and splitC) else ["DAPI"],
+            z_plan={"range": Z_RANGE, "step": STEP_SIZE} if Z else {},
+            time_plan={"interval": 1, "loops": 2} if T else {},
+        )
+        sequence.metadata[SEQUENCE_META_KEY] = SequenceMeta(
+            mode="mda", split_channels=bool(C and splitC)
+        )
 
-    _mda.stack_groupbox.setChecked(bool(Z))
-    _mda.stack_groupbox._zmode_tabs.setCurrentIndex(1)
-    z_range_wdg = _mda.stack_groupbox._zmode_tabs.widget(1)
-    assert isinstance(z_range_wdg, ZRangeAroundSelect)
+        # create zarr layer
+        main_window._on_mda_started(sequence)
+        assert len(list(main_window.viewer.layers)) == 2 if (C and splitC) else 1
 
-    z_range_wdg._zrange_spinbox.setValue(Z_RANGE)
-    _mda.stack_groupbox._zstep_spinbox.setValue(STEP_SIZE)
-
-    # 2 Channels
-    _mda.channel_groupbox.add_ch_button.click()
-    _mda.channel_groupbox.channel_tableWidget.cellWidget(0, 1).setValue(5)
-    if C:
-        _mda.channel_groupbox.add_ch_button.click()
-        _mda.channel_groupbox.channel_tableWidget.cellWidget(1, 1).setValue(5)
-    if C and splitC:
-        _mda.checkBox_split_channels.setChecked(True)
-
-    mmc = main_window._mmc
-    mda = _mda.get_state()
-    mda.metadata[SEQUENCE_META_KEY] = SequenceMeta(
-        mode="mda", split_channels=_mda.checkBox_split_channels.isChecked()
-    )
-
-    main_window._on_mda_started(mda)
-
-    layer = main_window.viewer.layers[-1]
-    # if mda.z_plan, z stack will have 4 images
-    if len(mda.z_plan) == 4:
-        data_shape = layer.data.shape
-        assert layer.scale[data_shape.index(4)] == float(STEP_SIZE)
-    else:
-        for idx, val in enumerate(reversed(layer.scale)):
-            if idx <= 1:
-                assert val == mmc.getPixelSizeUm()
-            else:
-                assert val == 1.0
+        layer = main_window.viewer.layers[0]
+        if Z:
+            assert layer.scale[layer.data.shape.index(len(sequence.z_plan))] == float(
+                STEP_SIZE
+            )
+        else:
+            for idx, val in enumerate(reversed(layer.scale)):
+                if idx <= 1:
+                    assert val == mmc.getPixelSizeUm()
+                else:
+                    assert val == 1.0
+        main_window.viewer.layers.clear()
+        assert not list(main_window.viewer.layers)

--- a/tests/test_layer_scale.py
+++ b/tests/test_layer_scale.py
@@ -67,4 +67,3 @@ def test_layer_scale(qtbot: QtBot, main_window: MainWindow, T, C, splitC, Z):
                 assert val == mmc.getPixelSizeUm()
             else:
                 assert val == 1.0
-    assert list(layer.scale) == main_window._get_scale_from_sequence(mda, layer)

--- a/tests/test_layer_scale.py
+++ b/tests/test_layer_scale.py
@@ -23,7 +23,7 @@ def test_layer_scale(qtbot: QtBot, main_window: MainWindow, Z, C, splitC, T):
     mmc = main_window._mmc
     mmc.setProperty("Objective", "Label", "Nikon 20X Plan Fluor ELWD")
 
-    for order in ["tpcz", "tpzc"]:
+    for order in ["tpcz", "tpzc", "ptcz", "ptzc"]:
         sequence = MDASequence(
             axis_order=order,
             channels=["DAPI", "Cy5"] if (C and splitC) else ["DAPI"],

--- a/tests/test_layer_scale.py
+++ b/tests/test_layer_scale.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from napari_micromanager._mda_meta import SEQUENCE_META_KEY, SequenceMeta
 from napari_micromanager.main_window import MainWindow
 from useq import MDASequence
 
@@ -13,8 +12,6 @@ def test_layer_scale(main_window: MainWindow, mda_sequence_splits: MDASequence) 
     for order in ["tpcz", "tpzc"]:
         sequence = mda_sequence_splits
         sequence = sequence.replace(axis_order=order)
-        meta: SequenceMeta = sequence.metadata[SEQUENCE_META_KEY]
-        sequence.metadata[SEQUENCE_META_KEY] = meta
 
         # create zarr layer
         main_window._on_mda_started(sequence)

--- a/tests/test_layer_scale.py
+++ b/tests/test_layer_scale.py
@@ -15,13 +15,14 @@ def test_layer_scale(
     mmc = main_window._mmc
     mmc.setProperty("Objective", "Label", "Nikon 20X Plan Fluor ELWD")
     sequence = mda_sequence_splits.replace(axis_order=axis_order)
+    z_step = sequence.z_plan and sequence.z_plan.step
 
     # create zarr layer
     main_window._on_mda_started(sequence)
 
     layer = main_window.viewer.layers[0]
     if sequence.z_plan:
-        assert layer.scale[layer.data.shape.index(len(sequence.z_plan))] == 1.0
+        assert layer.scale[layer.data.shape.index(len(sequence.z_plan))] == z_step
     else:
         expect = [1] * (layer.data.ndim - 2) + [mmc.getPixelSizeUm()] * 2
         assert tuple(layer.scale) == tuple(expect)

--- a/tests/test_layer_scale.py
+++ b/tests/test_layer_scale.py
@@ -1,48 +1,27 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-import pytest
 from napari_micromanager._mda_meta import SEQUENCE_META_KEY, SequenceMeta
 from napari_micromanager.main_window import MainWindow
 from useq import MDASequence
 
-if TYPE_CHECKING:
-    from pytestqt.qtbot import QtBot
 
-
-@pytest.mark.parametrize("Z", ["", "withZ"])
-@pytest.mark.parametrize("C", ["", "withC"])
-@pytest.mark.parametrize("splitC", ["", "splitC"])
-@pytest.mark.parametrize("T", ["", "withT"])
-def test_layer_scale(qtbot: QtBot, main_window: MainWindow, Z, C, splitC, T):
-
-    Z_RANGE = 5
-    STEP_SIZE = 2
+def test_layer_scale(main_window: MainWindow, mda_sequence_splits: MDASequence) -> None:
 
     mmc = main_window._mmc
     mmc.setProperty("Objective", "Label", "Nikon 20X Plan Fluor ELWD")
 
-    for order in ["tpcz", "tpzc", "ptcz", "ptzc"]:
-        sequence = MDASequence(
-            axis_order=order,
-            channels=["DAPI", "Cy5"] if (C and splitC) else ["DAPI"],
-            z_plan={"range": Z_RANGE, "step": STEP_SIZE} if Z else {},
-            time_plan={"interval": 1, "loops": 2} if T else {},
-        )
-        sequence.metadata[SEQUENCE_META_KEY] = SequenceMeta(
-            mode="mda", split_channels=bool(C and splitC)
-        )
+    for order in ["tpcz", "tpzc"]:
+        sequence = mda_sequence_splits
+        sequence = sequence.replace(axis_order=order)
+        meta: SequenceMeta = sequence.metadata[SEQUENCE_META_KEY]
+        sequence.metadata[SEQUENCE_META_KEY] = meta
 
         # create zarr layer
         main_window._on_mda_started(sequence)
-        assert len(list(main_window.viewer.layers)) == 2 if (C and splitC) else 1
 
         layer = main_window.viewer.layers[0]
-        if Z:
-            assert layer.scale[layer.data.shape.index(len(sequence.z_plan))] == float(
-                STEP_SIZE
-            )
+        if sequence.z_plan:
+            assert layer.scale[layer.data.shape.index(len(sequence.z_plan))] == 1.0
         else:
             for idx, val in enumerate(reversed(layer.scale)):
                 if idx <= 1:

--- a/tests/test_layer_scale.py
+++ b/tests/test_layer_scale.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from napari_micromanager._gui_objects._mda_widget import MultiDWidget
+from napari_micromanager.main_window import MainWindow
+from pymmcore_widgets._zstack_widget import ZRangeAroundSelect
+from useq import MDASequence
+
+if TYPE_CHECKING:
+    from pytestqt.qtbot import QtBot
+
+
+@pytest.mark.parametrize("Z", ["", "withZ"])
+@pytest.mark.parametrize("splitC", ["", "splitC"])
+@pytest.mark.parametrize("C", ["", "withC"])
+@pytest.mark.parametrize("T", ["", "withT"])
+def test_layer_scale(qtbot: QtBot, main_window: MainWindow, T, C, splitC, Z):
+
+    Z_RANGE = 5
+    STEP_SIZE = 2
+    mmc = main_window._mmc
+    mmc.setProperty("Objective", "Label", "Nikon 20X Plan Fluor ELWD")
+    main_window._show_dock_widget("MDA")
+    _mda = main_window._dock_widgets["MDA"].widget()
+    assert isinstance(_mda, MultiDWidget)
+
+    _mda.time_groupbox.setChecked(bool(T))
+    _mda.time_groupbox.time_comboBox.setCurrentText("ms")
+    _mda.time_groupbox.timepoints_spinBox.setValue(3)
+    _mda.time_groupbox.interval_spinBox.setValue(250)
+
+    _mda.stack_groupbox.setChecked(bool(Z))
+    _mda.stack_groupbox._zmode_tabs.setCurrentIndex(1)
+    z_range_wdg = _mda.stack_groupbox._zmode_tabs.widget(1)
+    assert isinstance(z_range_wdg, ZRangeAroundSelect)
+
+    z_range_wdg._zrange_spinbox.setValue(Z_RANGE)
+    _mda.stack_groupbox._zstep_spinbox.setValue(STEP_SIZE)
+
+    # 2 Channels
+    _mda.channel_groupbox.add_ch_button.click()
+    _mda.channel_groupbox.channel_tableWidget.cellWidget(0, 1).setValue(5)
+    if C:
+        _mda.channel_groupbox.add_ch_button.click()
+        _mda.channel_groupbox.channel_tableWidget.cellWidget(1, 1).setValue(5)
+    if C and splitC:
+        _mda.checkBox_split_channels.setChecked(True)
+
+    mmc = main_window._mmc
+    mda: MDASequence | None = None
+
+    @mmc.mda.events.sequenceStarted.connect
+    def _store_mda(_mda: MDASequence):
+        nonlocal mda
+        mda = _mda
+
+    with qtbot.waitSignal(mmc.mda.events.sequenceFinished, timeout=10000):
+        _mda.buttons_wdg.run_button.click()
+
+    assert mda is not None
+
+    layer = main_window.viewer.layers[-1]
+    data_shape = layer.data.shape
+    # if mda.z_plan, z stack will have 4 images
+    if len(mda.z_plan) == 4:
+        assert layer.scale[data_shape.index(4)] == float(STEP_SIZE)
+    else:
+        for idx, val in enumerate(reversed(layer.scale)):
+            if idx <= 1:
+                assert val == 0.5
+            else:
+                assert val == 1.0
+    assert list(layer.scale) == main_window._get_scale_from_sequence(mda, layer)

--- a/tests/test_multid_widget.py
+++ b/tests/test_multid_widget.py
@@ -14,7 +14,6 @@ from pymmcore_widgets._zstack_widget import ZRangeAroundSelect
 from useq import MDASequence
 
 if TYPE_CHECKING:
-    import napari.layers
     from pytestqt.qtbot import QtBot
 
 
@@ -140,6 +139,4 @@ def test_script_initiated_mda(main_window: MainWindow, qtbot: QtBot):
     viewer = main_window.viewer
     viewer_layer_names = [layer.name for layer in viewer.layers]
     assert layer_name in viewer_layer_names
-    layer: napari.layers.Image = viewer.layers[layer_name]
-    assert list(layer.scale) == main_window._get_scale_from_sequence(sequence, layer)
     assert sequence.shape == viewer.layers[layer_name].data.shape[:-2]

--- a/tests/test_multid_widget.py
+++ b/tests/test_multid_widget.py
@@ -14,6 +14,7 @@ from pymmcore_widgets._zstack_widget import ZRangeAroundSelect
 from useq import MDASequence
 
 if TYPE_CHECKING:
+    import napari.layers
     from pytestqt.qtbot import QtBot
 
 
@@ -141,4 +142,6 @@ def test_script_initiated_mda(main_window: MainWindow, qtbot: QtBot):
     viewer = main_window.viewer
     viewer_layer_names = [layer.name for layer in viewer.layers]
     assert layer_name in viewer_layer_names
+    layer: napari.layers.Image = viewer.layers[layer_name]
+    assert list(layer.scale) == main_window._get_scale_from_sequence(sequence, layer)
     assert sequence.shape == viewer.layers[layer_name].data.shape[:-2]


### PR DESCRIPTION
This PR adds a `layer.scale` info to all the image layers acquire through `napari-micromanager` (mda, explorer, preview).