### PR TITLE
refactor: cleanup connections in MainWindow

### DIFF
--- a/src/napari_micromanager/_gui_objects/_shutters_widget.py
+++ b/src/napari_micromanager/_gui_objects/_shutters_widget.py
@@ -28,8 +28,13 @@ class MMShuttersWidget(QWidget):
         self._clear()
 
         if not self._mmc.getLoadedDevicesOfType(DeviceType.ShutterDevice):
-            empty_shutter = ShuttersWidget("")
-            self.layout().addWidget(empty_shutter)
+            # FIXME:
+            # ShuttersWidget has not been tested with an empty device label...
+            # it raises all sorts of errors.
+            # if we want to have a "placeholder" widget, it needs more testing.
+
+            # empty_shutter = ShuttersWidget("")
+            # self.layout().addWidget(empty_shutter)
             return
 
         shutters_devs = list(self._mmc.getLoadedDevicesOfType(DeviceType.ShutterDevice))

--- a/src/napari_micromanager/main_window.py
+++ b/src/napari_micromanager/main_window.py
@@ -60,7 +60,7 @@ class MainWindow(MicroManagerToolbar):
         # from core when this widget is closed.
         self._connections: list[tuple[PSignalInstance, Callable]] = [
             (self._mmc.events.exposureChanged, self._update_live_exp),
-            (self._mmc.events.imageSnapped, self.update_viewer),
+            (self._mmc.events.imageSnapped, self._update_viewer),
             (self._mmc.events.imageSnapped, self._stop_live),
             (self._mmc.events.continuousSequenceAcquisitionStarted, self._start_live),
             (self._mmc.events.sequenceAcquisitionStopped, self._stop_live),
@@ -99,8 +99,8 @@ class MainWindow(MicroManagerToolbar):
         atexit.unregister(self._cleanup)  # doesn't raise if not connected
 
     @ensure_main_thread  # type: ignore [misc]
-    def update_viewer(self, data: np.ndarray | None = None) -> None:
-        """Update viewer with the latest image from the camera."""
+    def _update_viewer(self, data: np.ndarray | None = None) -> None:
+        """Update viewer with the latest image from the circular buffer."""
         if data is None:
             try:
                 data = self._mmc.getLastImage()
@@ -149,7 +149,7 @@ class MainWindow(MicroManagerToolbar):
 
     def _start_live(self) -> None:
         self.streaming_timer = QTimer()
-        self.streaming_timer.timeout.connect(self.update_viewer)
+        self.streaming_timer.timeout.connect(self._update_viewer)
         self.streaming_timer.start(int(self._mmc.getExposure()))
 
     def _stop_live(self) -> None:

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from napari_micromanager.main_window import MainWindow
+from pymmcore_plus import CMMCorePlus
+
+if TYPE_CHECKING:
+    from pytestqt.qtbot import QtBot
+
+
+def test_main_window(qtbot: QtBot) -> None:
+    """Basic test to check that the main window can be created.
+
+    This test should remain fast.
+    """
+    viewer = MagicMock()
+    wdg = MainWindow(viewer)
+    qtbot.addWidget(wdg)
+
+    viewer.layers.events.connect.assert_called_once_with(wdg._update_max_min)
+
+    core = CMMCorePlus.instance()
+    core.loadSystemConfiguration()
+
+    wdg._snap()
+
+    wdg._update_viewer()
+    wdg._mmc.startContinuousSequenceAcquisition()
+    wdg._mmc.stopSequenceAcquisition()
+    wdg._update_viewer()
+
+    wdg._cleanup()
+    viewer.layers.events.disconnect.assert_called_once_with(wdg._update_max_min)


### PR DESCRIPTION
Mostly just puts all connections to external objects in one clear place.  Also adds a smoke test for the main window.

@fdrgsp ... I did find one problem, and that is the `empty_shutter = ShuttersWidget("")` that you add to the layout.  I don't think the pymmcore-widgets `ShuttersWidget` is ready for any random string (it isn't tested for it at least) ... it generally seems to assume that it's going to get a valid device label.  I found that it would raise an error in certain cases if you create a MainWindow _without_ already having had loaded a system configuration.  And even if you load one later... it's too late, the broken shutter widget has already connected itself to core.