### PR TITLE
refactor: use properties widget from pymmcore-widgets for illum widget

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "fonticon-materialdesignicons6",
     "tifffile",
     "zarr",
-    "pymmcore-widgets >=0.2.0",
+    "pymmcore-widgets >=0.2.1",
 ]
 
 # extras

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,14 +34,14 @@ classifiers = [
 
 dynamic = ["version"]
 dependencies = [
+    "fonticon-materialdesignicons6",
     "napari >=0.4.13",
     "pymmcore-plus >=0.6.3",
-    "useq-schema >=0.1.0",
-    "superqt >=0.3.1",
-    "fonticon-materialdesignicons6",
-    "tifffile",
-    "zarr",
     "pymmcore-widgets >=0.2.1",
+    "superqt >=0.3.1",
+    "tifffile",
+    "useq-schema >=0.1.0",
+    "zarr",
 ]
 
 # extras

--- a/src/napari_micromanager/_gui_objects/_illumination_widget.py
+++ b/src/napari_micromanager/_gui_objects/_illumination_widget.py
@@ -1,61 +1,26 @@
-import re
-from typing import Optional, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from pymmcore_plus import CMMCorePlus, PropertyType
-from pymmcore_widgets import PropertyWidget
-from qtpy.QtWidgets import QGridLayout, QLabel, QSizePolicy, QWidget
+from pymmcore_widgets import PropertiesWidget
 
-from .._util import iter_dev_props
+if TYPE_CHECKING:
+    from qtpy.QtWidgets import QWidget
 
 
-class IlluminationWidget(QWidget):
+class IlluminationWidget(PropertiesWidget):
     """Sliders widget to control illumination."""
 
     def __init__(
         self,
-        property_regex: str = "(Intensity|Power|test)s?",
         *,
-        parent: Optional[QWidget] = None,
-        mmcore: Optional[CMMCorePlus] = None,
+        parent: QWidget | None = None,
+        mmcore: CMMCorePlus | None = None,
     ):
-        super().__init__(parent=parent)
-
-        self.setLayout(QGridLayout())
-
-        self.ptrn = re.compile(property_regex, re.IGNORECASE)
-        self._mmc = mmcore or CMMCorePlus.instance()
-        self._mmc.events.systemConfigurationLoaded.connect(self._on_cfg_loaded)
-
-        self.destroyed.connect(self._disconnect)
-
-        self._on_cfg_loaded()
-
-        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-
-    def _create_wdg(self) -> None:
-
-        lights = [
-            dp
-            for dp in iter_dev_props(self._mmc)
-            if self.ptrn.search(dp[1])
-            and self._mmc.hasPropertyLimits(*dp)
-            and self._mmc.getPropertyType(*dp)
-            in {PropertyType.Integer, PropertyType.Float}
-        ]
-        layout = cast(QGridLayout, self.layout())
-        for i, (dev, prop) in enumerate(lights):
-            layout.addWidget(QLabel(f"{dev}::{prop}"), i, 0)
-            layout.addWidget(PropertyWidget(dev, prop, mmcore=self._mmc), i, 1)
-
-    def _on_cfg_loaded(self) -> None:
-        self._clear()
-        self._create_wdg()
-
-    def _clear(self) -> None:
-        for i in reversed(range(self.layout().count())):
-            if item := self.layout().takeAt(i):
-                if wdg := item.widget():
-                    wdg.deleteLater()
-
-    def _disconnect(self) -> None:
-        self._mmc.events.systemConfigurationLoaded.disconnect(self._on_cfg_loaded)
+        super().__init__(
+            property_name_pattern="(Intensity|Power|test)s?",
+            property_type={PropertyType.Integer, PropertyType.Float},
+            parent=parent,
+            mmcore=mmcore,
+        )

--- a/src/napari_micromanager/_util.py
+++ b/src/napari_micromanager/_util.py
@@ -4,7 +4,6 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterator
 
-from pymmcore_plus import CMMCorePlus
 
 if TYPE_CHECKING:
     import useq
@@ -51,11 +50,3 @@ def event_indices(event: useq.MDAEvent) -> Iterator[str]:
     for k in event.sequence.axis_order if event.sequence else []:
         if k in event.index:
             yield k
-
-
-def iter_dev_props(mmc: CMMCorePlus | None = None) -> Iterator[tuple[str, str]]:
-    """Yield all pairs of currently loaded (device_label, property_name)."""
-    mmc = mmc or CMMCorePlus.instance()
-    for dev in mmc.getLoadedDevices():
-        for prop in mmc.getDevicePropertyNames(dev):
-            yield dev, prop


### PR DESCRIPTION
Will use https://github.com/pymmcore-plus/pymmcore-widgets/pull/90 in place of the Illumination widget.

This will fail until v0.2.1 of widgets is released