### PR TITLE
test: add `mda_sequence` parametrized fixture

### DIFF
--- a/src/napari_micromanager/_gui_objects/_mda_widget.py
+++ b/src/napari_micromanager/_gui_objects/_mda_widget.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Optional, cast
+from typing import cast
 
 from pymmcore_plus import CMMCorePlus
 from pymmcore_widgets import MDAWidget
@@ -26,7 +28,7 @@ class MultiDWidget(MDAWidget):
     """Main napari-micromanager GUI."""
 
     def __init__(
-        self, *, parent: Optional[QWidget] = None, mmcore: Optional[CMMCorePlus] = None
+        self, *, parent: QWidget | None = None, mmcore: CMMCorePlus | None = None
     ) -> None:
         super().__init__(include_run_button=True, parent=parent, mmcore=mmcore)
 

--- a/src/napari_micromanager/_gui_objects/_sample_explorer_widget.py
+++ b/src/napari_micromanager/_gui_objects/_sample_explorer_widget.py
@@ -16,6 +16,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from useq import MDASequence
 
 from .._mda_meta import SEQUENCE_META_KEY, SequenceMeta
 
@@ -166,11 +167,8 @@ class SampleExplorer(SampleExplorerWidget):
             t_list = t_list * self.stage_pos_groupbox.stage_tableWidget.rowCount()
         return t_list
 
-    def _start_scan(self) -> None:
-        """Run the MDA sequence experiment."""
-        # construct a `useq.MDASequence` object from the values inserted in the widget
-        sequence = self.get_state()
-
+    def get_state(self) -> MDASequence:
+        sequence = cast(MDASequence, super().get_state())
         sequence.metadata[SEQUENCE_META_KEY] = SequenceMeta(
             mode="explorer",
             should_save=self.save_explorer_groupbox.isChecked(),
@@ -182,7 +180,4 @@ class SampleExplorer(SampleExplorerWidget):
             scan_size_c=self.scan_size_c,
             scan_size_r=self.scan_size_r,
         )
-
-        # run the MDA experiment asynchronously
-        self._mmc.run_mda(sequence)
-        return
+        return sequence

--- a/src/napari_micromanager/_mda_meta.py
+++ b/src/napari_micromanager/_mda_meta.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from dataclasses import replace as _replace
+from typing import Any
 
 
 __all__ = ["SequenceMeta", "SEQUENCE_META_KEY"]
@@ -12,7 +14,7 @@ __all__ = ["SequenceMeta", "SEQUENCE_META_KEY"]
 SEQUENCE_META_KEY = "napari_mm_sequence_meta"
 
 
-@dataclass
+@dataclass(frozen=True)
 class SequenceMeta:
     """Metadata associated with an MDA sequence."""
 
@@ -26,3 +28,7 @@ class SequenceMeta:
     explorer_translation_points: list = field(default_factory=list)
     scan_size_r: int = 0
     scan_size_c: int = 0
+
+    def replace(self, **kwargs: Any) -> SequenceMeta:
+        """Return a new SequenceMeta with the given kwargs replaced."""
+        return _replace(self, **kwargs)

--- a/src/napari_micromanager/main_window.py
+++ b/src/napari_micromanager/main_window.py
@@ -89,7 +89,7 @@ class MainWindow(MicroManagerToolbar):
 
     def _cleanup(self) -> None:
         for signal, slot in self._connections:
-            with contextlib.suppress(RuntimeError):
+            with contextlib.suppress(TypeError):
                 signal.disconnect(slot)
         # Clean up temporary files we opened.
         for v in self._mda_temp_files.values():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,9 +35,13 @@ MDAS = [
     {"time_plan": t, "z_plan": z, "channels": c}
     for t, z, c in itertools.product(TIME_PLANS, Z_PLANS, CHANNEL_PLANS)
 ]
+MDA_IDS = [
+    f"nT={t and len(t)}-nZ={z and len(z)}-nC={len(c)}"
+    for t, z, c in itertools.product(TIME_PLANS, Z_PLANS, CHANNEL_PLANS)
+]
 
 
-@pytest.fixture(params=MDAS)
+@pytest.fixture(params=MDAS, ids=MDA_IDS)
 def mda_sequence(request) -> useq.MDASequence:
     meta = {
         SEQUENCE_META_KEY: SequenceMeta(
@@ -47,7 +51,7 @@ def mda_sequence(request) -> useq.MDASequence:
     return useq.MDASequence(**request.param, metadata=meta)
 
 
-@pytest.fixture(params=[True, False])
+@pytest.fixture(params=[True, False], ids=["splitC", "no_splitC"])
 def mda_sequence_splits(mda_sequence: useq.MDASequence, request) -> useq.MDASequence:
     if request.param:
         meta: SequenceMeta = mda_sequence.metadata[SEQUENCE_META_KEY]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,10 @@ import itertools
 from pathlib import Path
 
 import pytest
-from napari_micromanager.main_window import MainWindow
-
-from napari_micromanager._mda_meta import SEQUENCE_META_KEY, SequenceMeta
-from pymmcore_plus import CMMCorePlus
-from itertools import product
 import useq
+from napari_micromanager._mda_meta import SEQUENCE_META_KEY, SequenceMeta
+from napari_micromanager.main_window import MainWindow
+from pymmcore_plus import CMMCorePlus
 
 # to create a new CMMCorePlus() for every test
 @pytest.fixture
@@ -41,12 +39,18 @@ MDAS = [
 
 @pytest.fixture(params=MDAS)
 def mda_sequence(request) -> useq.MDASequence:
-    meta = {SEQUENCE_META_KEY: SequenceMeta(mode="mda", file_name="test_mda")}
+    meta = {
+        SEQUENCE_META_KEY: SequenceMeta(
+            mode="mda", file_name="test_mda", should_save=True
+        )
+    }
     return useq.MDASequence(**request.param, metadata=meta)
 
 
 @pytest.fixture(params=[True, False])
 def mda_sequence_splits(mda_sequence: useq.MDASequence, request) -> useq.MDASequence:
     if request.param:
-        mda_sequence.metadata[SEQUENCE_META_KEY].split_channels = True
+        meta: SequenceMeta = mda_sequence.metadata[SEQUENCE_META_KEY]
+        meta = meta.replace(split_channels=True)
+        mda_sequence.metadata[SEQUENCE_META_KEY] = meta
     return mda_sequence

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,13 @@
+import itertools
 from pathlib import Path
 
 import pytest
 from napari_micromanager.main_window import MainWindow
-from pymmcore_plus import CMMCorePlus
 
+from napari_micromanager._mda_meta import SEQUENCE_META_KEY, SequenceMeta
+from pymmcore_plus import CMMCorePlus
+from itertools import product
+import useq
 
 # to create a new CMMCorePlus() for every test
 @pytest.fixture
@@ -21,3 +25,28 @@ def main_window(core: CMMCorePlus, make_napari_viewer):
     config_path = str(Path(__file__).parent / "test_config.cfg")
     win._mmc.loadSystemConfiguration(config_path)
     return win
+
+
+TIME_PLANS = (None, useq.TIntervalLoops(loops=3, interval=0.250))
+Z_PLANS = (None, useq.ZRangeAround(range=3, step=1))
+CHANNEL_PLANS = (
+    (useq.Channel(config="DAPI", exposure=5),),
+    (useq.Channel(config="DAPI", exposure=5), useq.Channel(config="Cy5", exposure=5)),
+)
+MDAS = [
+    {"time_plan": t, "z_plan": z, "channels": c}
+    for t, z, c in itertools.product(TIME_PLANS, Z_PLANS, CHANNEL_PLANS)
+]
+
+
+@pytest.fixture(params=MDAS)
+def mda_sequence(request) -> useq.MDASequence:
+    meta = {SEQUENCE_META_KEY: SequenceMeta(mode="mda", file_name="test_mda")}
+    return useq.MDASequence(**request.param, metadata=meta)
+
+
+@pytest.fixture(params=[True, False])
+def mda_sequence_splits(mda_sequence: useq.MDASequence, request) -> useq.MDASequence:
+    if request.param:
+        mda_sequence.metadata[SEQUENCE_META_KEY].split_channels = True
+    return mda_sequence

--- a/tests/test_multid_widget.py
+++ b/tests/test_multid_widget.py
@@ -39,46 +39,19 @@ def test_main_window_mda(main_window: MainWindow):
     assert main_window.viewer.layers[-1].data.shape == (4, 2, 4, 512, 512)
 
 
-@pytest.mark.parametrize("Z", ["", "withZ"])
-@pytest.mark.parametrize("splitC", ["", "splitC"])
-@pytest.mark.parametrize("C", ["", "withC"])
-@pytest.mark.parametrize("T", ["", "withT"])
 def test_saving_mda(
-    qtbot: QtBot, main_window: MainWindow, T, C, splitC, Z, tmp_path: Path
-):
+    qtbot: QtBot,
+    main_window: MainWindow,
+    mda_sequence_splits: MDASequence,
+    tmp_path: Path,
+) -> None:
+    mda = mda_sequence_splits
+    meta: SequenceMeta = mda.metadata[SEQUENCE_META_KEY]
+    meta.save_dir = str(tmp_path)
 
-    NAME = "test_mda"
     main_window._show_dock_widget("MDA")
-    _mda = main_window._dock_widgets["MDA"].widget()
-    assert isinstance(_mda, MultiDWidget)
-    _mda.save_groupbox.setChecked(True)
-    _mda.dir_lineEdit.setText(str(tmp_path))
-    _mda.fname_lineEdit.setText(NAME)
-
-    _mda.time_groupbox.setChecked(bool(T))
-    _mda.time_groupbox.time_comboBox.setCurrentText("ms")
-    _mda.time_groupbox.timepoints_spinBox.setValue(3)
-    _mda.time_groupbox.interval_spinBox.setValue(250)
-
-    _mda.stack_groupbox.setChecked(bool(Z))
-    _mda.stack_groupbox._zmode_tabs.setCurrentIndex(1)
-    z_range_wdg = _mda.stack_groupbox._zmode_tabs.widget(1)
-    assert isinstance(z_range_wdg, ZRangeAroundSelect)
-    z_range_wdg._zrange_spinbox.setValue(3)
-    _mda.stack_groupbox._zstep_spinbox.setValue(1)
-
-    # 2 Channels
-    _mda.channel_groupbox.add_ch_button.click()
-    _mda.channel_groupbox.channel_tableWidget.cellWidget(0, 0).setCurrentText("DAPI")
-    _mda.channel_groupbox.channel_tableWidget.cellWidget(0, 1).setValue(5)
-    if C:
-        _mda.channel_groupbox.add_ch_button.click()
-        _mda.channel_groupbox.channel_tableWidget.cellWidget(1, 0).setCurrentText("Cy5")
-        _mda.channel_groupbox.channel_tableWidget.cellWidget(1, 1).setValue(5)
-    if C and splitC:
-        _mda.checkBox_split_channels.setChecked(True)
-
-    mda: MDASequence | None = None
+    mda_widget = main_window._dock_widgets["MDA"].widget()
+    assert isinstance(mda_widget, MultiDWidget)
 
     mmc = main_window._mmc
     # re-register twice to fully exercise the logic of the update
@@ -88,36 +61,28 @@ def test_saving_mda(
     mmc.register_mda_engine(MDAEngine(mmc))
     mmc.register_mda_engine(MDAEngine(mmc))
 
-    @mmc.mda.events.sequenceStarted.connect
-    def _store_mda(_mda):
-        nonlocal mda
-        mda = _mda
-
     # make the images non-square
     mmc.setProperty("Camera", "OnCameraCCDYSize", 500)
-
     with qtbot.waitSignal(mmc.mda.events.sequenceFinished, timeout=10000):
-        _mda.buttons_wdg.run_button.click()
+        # mda_widget.buttons_wdg.run_button.click()
+        mmc.run_mda(mda)
 
-    assert mda is not None
     data_shape = main_window.viewer.layers[-1].data.shape
     expected_shape = list(mda.shape) + [500, 512]
 
-    if C and splitC:
+    multiC = len(mda.channels) > 1
+
+    if multiC and meta.split_channels:
         expected_shape.pop(list(event_indices(next(mda.iter_events()))).index("c"))
-    # back to tuple after manipulations with pop
-    # need to be tuple to compare equality to a tuple
-    expected_shape = tuple(expected_shape)
 
-    assert data_shape == expected_shape
+    assert data_shape == tuple(expected_shape)
 
-    if C and splitC:
-
-        nfiles = len(list((tmp_path / f"{NAME}_000").iterdir()))
-        assert nfiles == 2 if C else 1
+    if multiC and meta.split_channels:
+        nfiles = len(list((tmp_path / f"{meta.file_name}_000").iterdir()))
+        assert nfiles == 2 if multiC else 1
     else:
-        assert [p.name for p in tmp_path.iterdir()] == [f"{NAME}_000.tif"]
-        assert data_shape == expected_shape
+        assert [p.name for p in tmp_path.iterdir()] == [f"{meta.file_name}_000.tif"]
+        assert data_shape == tuple(expected_shape)
 
 
 def test_script_initiated_mda(main_window: MainWindow, qtbot: QtBot):


### PR DESCRIPTION
this adds a new `mda_sequence` fixture in conftest that should be used when we want to test something (such as MDA acquisition) across a handful of MDAs.

Note, I can't update the explorer widget in this PR since it's widget doesn't have a `set_state` method.... will do in a followup

cc @fdrgsp ... you could use this fixture in #225 to get a handful of MDA sequence objects