### PR TITLE
refactor: dedup save logic from explorer and mda

### DIFF
--- a/src/napari_micromanager/_gui_objects/_mda_widget.py
+++ b/src/napari_micromanager/_gui_objects/_mda_widget.py
@@ -3,25 +3,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import cast
 
+from napari_micromanager._mda_meta import SEQUENCE_META_KEY, SequenceMeta
 from pymmcore_plus import CMMCorePlus
 from pymmcore_widgets import MDAWidget
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import (
-    QCheckBox,
-    QFileDialog,
-    QGridLayout,
-    QGroupBox,
-    QHBoxLayout,
-    QLabel,
-    QLineEdit,
-    QPushButton,
-    QSizePolicy,
-    QVBoxLayout,
-    QWidget,
-)
+from qtpy.QtWidgets import QCheckBox, QGridLayout, QSizePolicy, QVBoxLayout, QWidget
 from useq import MDASequence
 
-from .._mda_meta import SEQUENCE_META_KEY, SequenceMeta
+from ._save_widget import SaveWidget
 
 
 class MultiDWidget(MDAWidget):
@@ -32,9 +21,14 @@ class MultiDWidget(MDAWidget):
     ) -> None:
         super().__init__(include_run_button=True, parent=parent, mmcore=mmcore)
 
-        self.save_groupbox = self._create_save_group()
+        self._save_groupbox = SaveWidget()
+        self._save_groupbox.setSizePolicy(
+            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed
+        )
+        self._save_groupbox.setChecked(False)
+
         v_layout = cast(QVBoxLayout, self._wdg.layout())
-        v_layout.insertWidget(0, self.save_groupbox)
+        v_layout.insertWidget(0, self._save_groupbox)
 
         self.channel_groupbox.setMinimumHeight(230)
         self.checkBox_split_channels = QCheckBox(text="Split Channels")
@@ -42,10 +36,10 @@ class MultiDWidget(MDAWidget):
         g_layout = cast(QGridLayout, self.channel_groupbox.layout())
         g_layout.addWidget(self.checkBox_split_channels, 1, 0)
 
-        self.browse_save_button.clicked.connect(self._set_multi_d_acq_dir)
-        self.save_groupbox.toggled.connect(self._toggle_checkbox_save_pos)
+        # TODO: stage_pos_groupbox should have a valueChanged signal
+        # and that should be connected to _toggle_checkbox_save_pos
+        self._save_groupbox.toggled.connect(self._toggle_checkbox_save_pos)
         self.stage_pos_groupbox.toggled.connect(self._toggle_checkbox_save_pos)
-
         self.stage_pos_groupbox.add_pos_button.clicked.connect(
             self._toggle_checkbox_save_pos
         )
@@ -60,67 +54,6 @@ class MultiDWidget(MDAWidget):
             self._toggle_split_channel
         )
 
-    def _create_save_group(self) -> QGroupBox:
-        group = QGroupBox(title="Save MultiD Acquisition")
-        group.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
-        group.setCheckable(True)
-        group.setChecked(False)
-        group_layout = QVBoxLayout()
-        group_layout.setSpacing(10)
-        group_layout.setContentsMargins(10, 10, 10, 10)
-        group.setLayout(group_layout)
-
-        # directory
-        dir_group = QWidget()
-        dir_group_layout = QHBoxLayout()
-        dir_group_layout.setSpacing(5)
-        dir_group_layout.setContentsMargins(0, 10, 0, 5)
-        dir_group.setLayout(dir_group_layout)
-        sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        min_lbl_size = 80
-        dir_lbl = QLabel(text="Directory:")
-        dir_lbl.setMinimumWidth(min_lbl_size)
-        dir_lbl.setSizePolicy(sizepolicy)
-        self.dir_lineEdit = QLineEdit()
-        self.browse_save_button = QPushButton(text="...")
-        self.browse_save_button.setSizePolicy(sizepolicy)
-        dir_group_layout.addWidget(dir_lbl)
-        dir_group_layout.addWidget(self.dir_lineEdit)
-        dir_group_layout.addWidget(self.browse_save_button)
-
-        # filename
-        fname_group = QWidget()
-        fname_group_layout = QHBoxLayout()
-        fname_group_layout.setSpacing(5)
-        fname_group_layout.setContentsMargins(0, 5, 0, 10)
-        fname_group.setLayout(fname_group_layout)
-        fname_lbl = QLabel(text="File Name: ")
-        fname_lbl.setMinimumWidth(min_lbl_size)
-        fname_lbl.setSizePolicy(sizepolicy)
-        self.fname_lineEdit = QLineEdit()
-        self.fname_lineEdit.setText("Experiment")
-        fname_group_layout.addWidget(fname_lbl)
-        fname_group_layout.addWidget(self.fname_lineEdit)
-
-        # checkbox
-        self.checkBox_save_pos = QCheckBox(
-            text="Save XY Positions in separate files (ImageJ compatibility)"
-        )
-
-        group_layout.addWidget(dir_group)
-        group_layout.addWidget(fname_group)
-        group_layout.addWidget(self.checkBox_save_pos)
-
-        return group
-
-    def _set_multi_d_acq_dir(self) -> None:
-        # set the directory
-        self.dir = QFileDialog(self)
-        self.dir.setFileMode(QFileDialog.FileMode.DirectoryOnly)
-        self.save_dir = QFileDialog.getExistingDirectory(self.dir)
-        self.dir_lineEdit.setText(self.save_dir)
-        self.parent_path = Path(self.save_dir)
-
     def _toggle_split_channel(self) -> None:
         if self.channel_groupbox.channel_tableWidget.rowCount() <= 1:
             self.checkBox_split_channels.setChecked(False)
@@ -130,22 +63,20 @@ class MultiDWidget(MDAWidget):
             self.stage_pos_groupbox.isChecked()
             and self.stage_pos_groupbox.stage_tableWidget.rowCount() > 0
         ):
-            self.checkBox_save_pos.setEnabled(True)
+            self._save_groupbox._split_pos_checkbox.setEnabled(True)
 
         else:
-            self.checkBox_save_pos.setCheckState(Qt.CheckState.Unchecked)
-            self.checkBox_save_pos.setEnabled(False)
+            self._save_groupbox._split_pos_checkbox.setCheckState(
+                Qt.CheckState.Unchecked
+            )
+            self._save_groupbox._split_pos_checkbox.setEnabled(False)
 
     def get_state(self) -> MDASequence:
         sequence = cast(MDASequence, super().get_state())
         sequence.metadata[SEQUENCE_META_KEY] = SequenceMeta(
             mode="mda",
             split_channels=self.checkBox_split_channels.isChecked(),
-            should_save=self.save_groupbox.isChecked(),
-            file_name=self.fname_lineEdit.text(),
-            save_dir=self.dir_lineEdit.text()
-            or str(Path(__file__).parent.parent.parent),
-            save_pos=self.checkBox_save_pos.isChecked(),
+            **self._save_groupbox.get_state(),
         )
         return sequence
 
@@ -165,7 +96,4 @@ class MultiDWidget(MDAWidget):
             raise ValueError(f"Expected mode 'mda', got {meta.mode}")
 
         self.checkBox_split_channels.setChecked(meta.split_channels)
-        self.save_groupbox.setChecked(meta.should_save)
-        self.fname_lineEdit.setText(meta.file_name)
-        self.dir_lineEdit.setText(meta.save_dir)
-        self.checkBox_save_pos.setChecked(meta.save_pos)
+        self._save_groupbox.set_state(meta)

--- a/src/napari_micromanager/_gui_objects/_save_widget.py
+++ b/src/napari_micromanager/_gui_objects/_save_widget.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from napari_micromanager._mda_meta import SequenceMeta
+from qtpy.QtWidgets import (
+    QCheckBox,
+    QFileDialog,
+    QGridLayout,
+    QGroupBox,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QWidget,
+)
+
+
+class SaveWidget(QGroupBox):
+    """A Widget to gather information about MDA file saving."""
+
+    def __init__(
+        self, title: str = "Save Acquisition", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(title, parent)
+        self.setCheckable(True)
+
+        # directory
+        self._directory = QLineEdit()
+        self._browse_save_btn = QPushButton(text="...")
+        self._browse_save_btn.clicked.connect(self._request_save_path)
+        # filename
+        self._fname = QLineEdit("Experiment")
+        # checkbox for splitting files by position
+        self._split_pos_checkbox = QCheckBox(
+            text="Save XY Positions in separate files (ImageJ compatibility)"
+        )
+
+        grid = QGridLayout()
+        self.setLayout(grid)
+        grid.setSpacing(10)
+        grid.setContentsMargins(10, 10, 10, 10)
+        grid.addWidget(QLabel("Directory:"), 0, 0)
+        grid.addWidget(self._directory, 0, 1)
+        grid.addWidget(self._browse_save_btn, 0, 2)
+        grid.addWidget(QLabel("File Name:"), 1, 0)
+        grid.addWidget(self._fname, 1, 1)
+        grid.addWidget(self._split_pos_checkbox, 2, 0, 1, 3)
+
+    def _request_save_path(self) -> None:
+        save_dir = QFileDialog.getExistingDirectory(self, "Select Save Directory")
+        if save_dir:
+            self._directory.setText(save_dir)
+
+    def get_state(self) -> dict:
+        """Return current state of the dialog.
+
+        All keys in this dict must kwargs for `SequenceMeta`.
+        """
+        return {
+            "file_name": self._fname.text(),
+            "save_dir": self._directory.text(),
+            "save_pos": self._split_pos_checkbox.isChecked(),
+            "should_save": self.isChecked(),
+        }
+
+    def set_state(self, meta: SequenceMeta) -> None:
+        self.setChecked(meta.should_save)
+        self._fname.setText(meta.file_name)
+        self._directory.setText(meta.save_dir)
+        self._split_pos_checkbox.setChecked(meta.save_pos)

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from napari_micromanager._gui_objects._sample_explorer_widget import SampleExplorer
@@ -103,11 +103,11 @@ def test_saving_explorer(
 
     NAME = "test_explorer"
     main_window._show_dock_widget("Explorer")
-    _exp = main_window._dock_widgets["Explorer"].widget()
+    _exp = cast(SampleExplorer, main_window._dock_widgets["Explorer"].widget())
     assert isinstance(_exp, SampleExplorer)
-    _exp.save_explorer_groupbox.setChecked(True)
-    _exp.dir_explorer_lineEdit.setText(str(tmp_path))
-    _exp.fname_explorer_lineEdit.setText(NAME)
+    _exp._save_groupbox.setChecked(True)
+    _exp._save_groupbox._directory.setText(str(tmp_path))
+    _exp._save_groupbox._fname.setText(NAME)
 
     _exp.scan_size_spinBox_r.setValue(2)
     _exp.scan_size_spinBox_c.setValue(1)


### PR DESCRIPTION
both the explorer and mda widgets have a `_create_save_group` that is essentially the same.  This pulls that out into a `SaveWidget`