### PR TITLE
refactor: pull minmax logic off main window, and reduce minmax widget layout logic

### DIFF
--- a/src/napari_micromanager/_gui_objects/_min_max_widget.py
+++ b/src/napari_micromanager/_gui_objects/_min_max_widget.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Iterable
 
-from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor
-from qtpy.QtWidgets import QHBoxLayout, QLabel, QScrollArea, QSizePolicy, QWidget
+from qtpy.QtWidgets import QLabel, QScrollArea, QWidget
 
 if TYPE_CHECKING:
     from napari.layers import Image
@@ -18,32 +18,18 @@ class MinMax(QScrollArea):
     def __init__(self, *, parent: QWidget | None = None) -> None:
         super().__init__(parent=parent)
         self.setWidgetResizable(True)
-        self.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
         self._label = QLabel()
-
-        lbl = QLabel("(min, max)")
-        lbl.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-
-        central = QWidget()
-        central.setLayout(QHBoxLayout())
-        central.layout().setContentsMargins(0, 0, 0, 0)
-        central.layout().addWidget(lbl)
-        central.layout().addWidget(self._label)
-        self.setWidget(central)
+        self.setWidget(self._label)
 
     def update_from_layers(self, layers: Iterable[Image]) -> None:
         """Update the minmax label based on data from layers."""
-        min_max_txt = ""
+        min_max_txt = "(min, max):  "
         for layer in layers:
             col = col if (col := layer.colormap.name) in QCOLORS else "gray"
             try:
                 minmax = tuple(layer._calc_data_range(mode="slice"))
+                min_max_txt += f' <font color="{col}">{minmax}</font>'
             except Exception:
-                import warnings
-
                 warnings.warn("cannot update minmax. napari api changed?")
-                continue
-            min_max_txt += f'<font color="{col}">{minmax}</font>'
 
         self._label.setText(min_max_txt)

--- a/src/napari_micromanager/_gui_objects/_min_max_widget.py
+++ b/src/napari_micromanager/_gui_objects/_min_max_widget.py
@@ -1,34 +1,49 @@
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable
 
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QHBoxLayout, QLabel, QScrollArea, QWidget
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QHBoxLayout, QLabel, QScrollArea, QSizePolicy, QWidget
+
+if TYPE_CHECKING:
+    from napari.layers import Image
+
+QCOLORS = set(QColor.colorNames())
 
 
-class MinMax(QWidget):
+class MinMax(QScrollArea):
     """A Widget to display min and max layer grey values."""
 
-    def __init__(self, *, parent: Optional[QWidget] = None) -> None:
+    def __init__(self, *, parent: QWidget | None = None) -> None:
         super().__init__(parent=parent)
+        self.setWidgetResizable(True)
+        self.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        self.setLayout(QHBoxLayout())
-        self.layout().setContentsMargins(0, 0, 0, 0)
+        self._label = QLabel()
 
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        lbl = QLabel("(min, max)")
+        lbl.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
-        max_min_wdg = QWidget()
-        max_min_wdg_layout = QHBoxLayout()
-        max_min_wdg_layout.setContentsMargins(0, 0, 0, 0)
-        max_min_wdg.setLayout(max_min_wdg_layout)
+        central = QWidget()
+        central.setLayout(QHBoxLayout())
+        central.layout().setContentsMargins(0, 0, 0, 0)
+        central.layout().addWidget(lbl)
+        central.layout().addWidget(self._label)
+        self.setWidget(central)
 
-        self.max_min_val_label_name = QLabel()
-        self.max_min_val_label_name.setText("(min, max)")
-        self.max_min_val_label_name.setMaximumWidth(70)
-        max_min_wdg_layout.addWidget(self.max_min_val_label_name)
+    def update_from_layers(self, layers: Iterable[Image]) -> None:
+        """Update the minmax label based on data from layers."""
+        min_max_txt = ""
+        for layer in layers:
+            col = col if (col := layer.colormap.name) in QCOLORS else "gray"
+            try:
+                minmax = tuple(layer._calc_data_range(mode="slice"))
+            except Exception:
+                import warnings
 
-        self.max_min_val_label = QLabel()
-        max_min_wdg_layout.addWidget(self.max_min_val_label)
+                warnings.warn("cannot update minmax. napari api changed?")
+                continue
+            min_max_txt += f'<font color="{col}">{minmax}</font>'
 
-        scroll.setWidget(max_min_wdg)
-        self.layout().addWidget(scroll)
+        self._label.setText(min_max_txt)

--- a/src/napari_micromanager/main_window.py
+++ b/src/napari_micromanager/main_window.py
@@ -9,7 +9,6 @@ import numpy as np
 from pymmcore_plus import CMMCorePlus
 from pymmcore_plus._util import find_micromanager
 from qtpy.QtCore import QTimer
-from qtpy.QtGui import QColor
 from superqt.utils import create_worker, ensure_main_thread
 
 from ._gui_objects._toolbar import MicroManagerToolbar
@@ -95,28 +94,11 @@ class MainWindow(MicroManagerToolbar):
         if self.streaming_timer is None:
             self.viewer.reset_view()
 
-    def _update_max_min(self, event: Any = None) -> None:
-
-        min_max_txt = ""
-        layers: list[napari.layers.Image] = [
-            lr
-            for lr in self.viewer.layers.selection
-            if isinstance(lr, napari.layers.Image) and lr.visible
-        ]
-
-        if not layers:
-            self.minmax.max_min_val_label.setText(min_max_txt)
-            return
-
-        for layer in layers:
-            col = layer.colormap.name
-            if col not in QColor.colorNames():
-                col = "gray"
-            # min and max of current slice
-            min_max_show = tuple(layer._calc_data_range(mode="slice"))
-            min_max_txt += f'<font color="{col}">{min_max_show}</font>'
-
-        self.minmax.max_min_val_label.setText(min_max_txt)
+    def _update_max_min(self, *_: Any) -> None:
+        visible = (x for x in self.viewer.layers.selection if x.visible)
+        self.minmax.update_from_layers(
+            (lr for lr in visible if isinstance(lr, napari.layers.Image))
+        )
 
     def _snap(self) -> None:
         # update in a thread so we don't freeze UI


### PR DESCRIPTION
puts the logic for updating minmax on the minmax widget itself, removing it from the main window.  Also simplifies the layout down to a couple lines