### PR TITLE
refactor: big cleanup of MDAHandler logic

### DIFF
--- a/src/napari_micromanager/_saving.py
+++ b/src/napari_micromanager/_saving.py
@@ -37,7 +37,7 @@ def save_sequence(sequence: MDASequence, layers: LayerList, meta: SequenceMeta) 
         return
     if not meta.should_save:
         return
-    if meta.mode == "mda":
+    if meta.mode in ("mda", ""):
         return _save_mda_sequence(sequence, layers, meta)
     if meta.mode == "explorer":
         return _save_explorer_scan(sequence, layers, meta)
@@ -63,7 +63,7 @@ def _save_mda_sequence(
         else:
             # save each channel layer.
             for lay in mda_layers:
-                fname = f'{folder_name.stem}{lay.metadata.get("ch_id")}.tif'
+                fname = f'{folder_name.stem}_{lay.metadata.get("ch_id")}.tif'
                 # TODO: smarter behavior w.r.t type of lay.data
                 # currently this will force the data into memory which may cause a crash
                 # long term solution is to remove this code and rely on an
@@ -107,7 +107,7 @@ def _save_pos_separately(
         for i in layers:
             if "ch_id" not in i.metadata or i.metadata.get("uid") != sequence.uid:
                 continue
-            filename = f"{fname}{i.metadata['ch_id']}_p{p:03}"
+            filename = f"{fname}_{i.metadata['ch_id']}_p{p:03}"
             ax = sequence.axis_order.index("p") if len(sequence.time_plan) > 0 else 0
             _imsave(folder_path / f"{filename}.tif", np.take(i.data, p, axis=ax))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,9 @@ import pytest
 import useq
 from napari_micromanager._mda_meta import SEQUENCE_META_KEY, SequenceMeta
 from napari_micromanager.main_window import MainWindow
-from pymmcore_plus import CMMCorePlus
+from pymmcore_plus import CMMCorePlus, _logger
+
+_logger.set_log_level("CRITICAL")
 
 # to create a new CMMCorePlus() for every test
 @pytest.fixture

--- a/tests/test_multid_widget.py
+++ b/tests/test_multid_widget.py
@@ -63,7 +63,7 @@ def test_saving_mda(
 
     # make the images non-square
     mmc.setProperty("Camera", "OnCameraCCDYSize", 500)
-    with qtbot.waitSignal(mmc.mda.events.sequenceFinished, timeout=5000):
+    with qtbot.waitSignal(mmc.mda.events.sequenceFinished, timeout=8000):
         mda_widget.buttons_wdg.run_button.click()
 
     data_shape = [x for x in main_window.viewer.layers[-1].data.shape if x > 1]


### PR DESCRIPTION
This PR gets rid of a number of mostly similar methods (with slightly different behavior for explorer vs mda):

- _interpret_split_channels
- _interpret_explorer_positions
- _get_shape_and_labels
- _get_channel_name_with_index
- _add_mda_channel_layers
- _add_explorer_positions_layers

and replaces them with two functions:

1.  `_determine_sequence_layers` - a pure stateless function (i.e. not a class method) that takes a `sequence` object, and returns information `(id, shape, metadata)` about all of the layers that need to be created for the experiment (based on whether C or P is being split.  Being stateless is particularly nice here, since it means it can be tested completely in absence of a core, a widget, a viewer, etc...  (but that will happen in a followup PR)  
2. `_create_empty_image_layer` - one method that creates the necessary layers.