### PR TITLE
fix: remove private import from pymmcore-widgets

### DIFF
--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -7,7 +7,6 @@ import pytest
 from napari_micromanager._gui_objects._sample_explorer_widget import SampleExplorer
 from napari_micromanager._mda_meta import SEQUENCE_META_KEY, SequenceMeta
 from pymmcore_plus.mda import MDAEngine
-from pymmcore_widgets._zstack_widget import ZRangeAroundSelect
 
 if TYPE_CHECKING:
     from napari_micromanager.main_window import MainWindow
@@ -121,7 +120,6 @@ def test_saving_explorer(
     _exp.stack_groupbox.setChecked(bool(Z))
     _exp.stack_groupbox._zmode_tabs.setCurrentIndex(1)
     z_range_wdg = _exp.stack_groupbox._zmode_tabs.widget(1)
-    assert isinstance(z_range_wdg, ZRangeAroundSelect)
     z_range_wdg._zrange_spinbox.setValue(3)
     _exp.stack_groupbox._zstep_spinbox.setValue(1)
 


### PR DESCRIPTION
I'm adding tests for napari-micromanager in pymmcore-widgets, and this failure popped up because we were importing private stuff from pymmcore-widgets here.

https://github.com/pymmcore-plus/pymmcore-widgets/actions/runs/3648433889/jobs/6161851543

just a reminder that even if the other library is our own library, you still want to be careful about importing and using private modules.  private implies that the library could change it without warning (and not worry about breaking any downstream library)