### PR TITLE
Fix test error from skimage warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ filterwarnings = [
     "ignore:distutils Version classes are deprecated",
     "ignore::DeprecationWarning:ipykernel",
     "ignore:<tifffile.TiffWriter.write> data with shape:DeprecationWarning:", # for napari
+    "ignore:.*bool8.*is a deprecated alias for.*bool_.*:DeprecationWarning:", # for skimage
 ]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html


### PR DESCRIPTION
Deals with this error:

```
ImportError while loading conftest '/home/ian/Documents/oss/micro/napari-micromanager/tests/conftest.py'.
tests/conftest.py:6: in <module>
    from napari_micromanager._mda_meta import SEQUENCE_META_KEY, SequenceMeta
src/napari_micromanager/__init__.py:9: in <module>
    from .main_window import MainWindow
src/napari_micromanager/main_window.py:15: in <module>
    from ._mda_handler import _NapariMDAHandler
src/napari_micromanager/_mda_handler.py:11: in <module>
    from napari.experimental import link_layers, unlink_layers
/home/ian/mambaforge/envs/micro-control-dev/lib/python3.10/site-packages/napari/experimental/__init__.py:1: in <module>
    from ..components.experimental.chunk import chunk_loader, synchronous_loading
/home/ian/mambaforge/envs/micro-control-dev/lib/python3.10/site-packages/napari/components/__init__.py:19: in <module>
    from .layerlist import LayerList
/home/ian/mambaforge/envs/micro-control-dev/lib/python3.10/site-packages/napari/components/layerlist.py:9: in <module>
    from ..layers import Layer
/home/ian/mambaforge/envs/micro-control-dev/lib/python3.10/site-packages/napari/layers/__init__.py:15: in <module>
    from .shapes import Shapes
/home/ian/mambaforge/envs/micro-control-dev/lib/python3.10/site-packages/napari/layers/shapes/__init__.py:1: in <module>
    from . import _shapes_key_bindings
/home/ian/mambaforge/envs/micro-control-dev/lib/python3.10/site-packages/napari/layers/shapes/_shapes_key_bindings.py:8: in <module>
    from ._shapes_constants import Box, Mode
/home/ian/mambaforge/envs/micro-control-dev/lib/python3.10/site-packages/napari/layers/shapes/_shapes_constants.py:5: in <module>
    from ._shapes_models import Ellipse, Line, Path, Polygon, Rectangle
/home/ian/mambaforge/envs/micro-control-dev/lib/python3.10/site-packages/napari/layers/shapes/_shapes_models/__init__.py:1: in <module>
    from .ellipse import Ellipse
/home/ian/mambaforge/envs/micro-control-dev/lib/python3.10/site-packages/napari/layers/shapes/_shapes_models/ellipse.py:4: in <module>
    from .._shapes_utils import (
/home/ian/mambaforge/envs/micro-control-dev/lib/python3.10/site-packages/napari/layers/shapes/_shapes_utils.py:4: in <module>
    from skimage.draw import line, polygon2mask
/home/ian/mambaforge/envs/micro-control-dev/lib/python3.10/site-packages/skimage/__init__.py:157: in <module>
    from .util.dtype import (img_as_float32,
/home/ian/mambaforge/envs/micro-control-dev/lib/python3.10/site-packages/skimage/util/__init__.py:4: in <module>
    from .dtype import (img_as_float32, img_as_float64, img_as_float,
/home/ian/mambaforge/envs/micro-control-dev/lib/python3.10/site-packages/skimage/util/dtype.py:27: in <module>
    np.bool8: (False, True),
/home/ian/mambaforge/envs/micro-control-dev/lib/python3.10/site-packages/numpy/__init__.py:260: in __getattr__
    warnings.warn(msg, DeprecationWarning, stacklevel=2)
E   DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)

```


Still kept some wildcards in there because I couldn't get the backticks to be recognized properly.