### PR TITLE
fix: Prevent crash when pixelSize = 0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ filterwarnings = [
     "ignore:distutils Version classes are deprecated",
     "ignore::DeprecationWarning:ipykernel",
     "ignore:<tifffile.TiffWriter.write> data with shape:DeprecationWarning:", # for napari
+    "ignore:.*bool8.*is a deprecated alias for.*bool_.*:DeprecationWarning:", # for skimage
 ]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html

--- a/src/napari_micromanager/_mda_handler.py
+++ b/src/napari_micromanager/_mda_handler.py
@@ -167,11 +167,12 @@ class _NapariMDAHandler:
         meta = cast(SequenceMeta, sequence.metadata.get(SEQUENCE_META_KEY))
 
         # add Z to layer scale
-        scale = [1.0] * (arr.ndim - 2) + [self._mmc.getPixelSizeUm()] * 2
-        if (index := sequence.used_axes.find("z")) > -1:
-            if meta.split_channels and sequence.used_axes.find("c") < index:
-                index -= 1
-            scale[index] = getattr(sequence.z_plan, "step", 1)
+        if (pix_size := self._mmc.getPixelSizeUm()) != 0:
+            scale = [1.0] * (arr.ndim - 2) + [pix_size] * 2
+            if (index := sequence.used_axes.find("z")) > -1:
+                if meta.split_channels and sequence.used_axes.find("c") < index:
+                    index -= 1
+                scale[index] = getattr(sequence.z_plan, "step", 1)
 
         return self.viewer.add_image(
             arr,

--- a/src/napari_micromanager/main_window.py
+++ b/src/napari_micromanager/main_window.py
@@ -87,7 +87,12 @@ class MainWindow(MicroManagerToolbar):
             preview_layer = self.viewer.add_image(data, name="preview")
 
         preview_layer.metadata["mode"] = "preview"
-        preview_layer.scale = (self._mmc.getPixelSizeUm(), self._mmc.getPixelSizeUm())
+
+        if (pix_size := self._mmc.getPixelSizeUm()) != 0:
+            preview_layer.scale = (pix_size, pix_size)
+        else:
+            # return to default
+            preview_layer.scale = [1.0, 1.0]
 
         self._update_max_min()
 

--- a/tests/test_layer_scale.py
+++ b/tests/test_layer_scale.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 from napari_micromanager._mda_handler import _NapariMDAHandler
+from napari_micromanager.main_window import MainWindow
 from pymmcore_plus import CMMCorePlus
 from useq import MDASequence
 
@@ -33,3 +34,27 @@ def test_layer_scale(
 
     # cleanup zarr resources
     handler._cleanup()
+
+
+def test_preview_scale(core: CMMCorePlus, main_window: MainWindow):
+    """Basic test to check that the main window can be created.
+
+    This test should remain fast.
+    """
+    img = core.snap()
+    main_window._update_viewer(img)
+
+    pix_size = core.getPixelSizeUm()
+    assert tuple(main_window.viewer.layers["preview"].scale) == (pix_size, pix_size)
+
+    # now pretend that the user never provided a pixel size config
+    # we need to not crash in this case
+
+    core.setPixelSizeUm("Res20x", 0)
+
+    try:
+        main_window._update_viewer(img)
+    except Exception as e:
+        # return to orig value for future tests and re-raise
+        core.setPixelSizeUm(pix_size)
+        raise e


### PR DESCRIPTION
If the user doesn't set the resolution in their config then we can an error in vispy

```
 File "C:\Users\TE-2000\mambaforge\envs\micro-control-fresh\lib\site-packages\numpy\linalg\linalg.py", line 89, 
in _raise_linalgerror_singular 
raise LinAlgError("Singular matrix")                                                                                                                                                           numpy.linalg.LinAlgError: Singular matrix   
```

This protects against that and adds a test - based on #243 in order to have tests semi functional