### PR TITLE
fix: fix _close_btn + add toolbar new line + propbrowser floating

### DIFF
--- a/src/napari_micromanager/_gui_objects/_toolbar.py
+++ b/src/napari_micromanager/_gui_objects/_toolbar.py
@@ -97,9 +97,13 @@ class MicroManagerToolbar(QMainWindow):
             self._add_snap_live_toolbar(),
             self._add_tools_toolsbar(),
             self._add_plugins_toolbar(),
+            "",
             self._add_shutter_toolbar(),
         ]
         for item in toolbar_items:
+            if not item:
+                self.addToolBarBreak(Qt.ToolBarArea.TopToolBarArea)
+                continue
             self.addToolBar(Qt.ToolBarArea.TopToolBarArea, item)
 
         self.installEventFilter(self)
@@ -342,6 +346,8 @@ class MicroManagerToolbar(QMainWindow):
         `key` must be a key in the DOCK_WIDGETS dict or a `str` stored in
         the `whatsThis` property of a `sender` `QPushButton`.
         """
+        floating = False
+        tabify = True
         if not key:
             # using QPushButton.whatsThis() property to get the key.
             btn = cast(QPushButton, self.sender())
@@ -372,8 +378,10 @@ class MicroManagerToolbar(QMainWindow):
                 wdg._prop_table.setVerticalScrollBarPolicy(
                     Qt.ScrollBarPolicy.ScrollBarAlwaysOff
                 )
+                floating = True
+                tabify = False
 
-            dock_wdg = self._add_dock_widget(wdg, key, tabify=True)
+            dock_wdg = self._add_dock_widget(wdg, key, floating=floating, tabify=tabify)
             self._dock_widgets[key] = dock_wdg
 
     def _add_dock_widget(
@@ -386,7 +394,7 @@ class MicroManagerToolbar(QMainWindow):
             area="right",
             tabify=tabify,
         )
-        dock_wdg.setFloating(floating)
         with contextlib.suppress(AttributeError):
             dock_wdg._close_btn = False
+        dock_wdg.setFloating(floating)
         return dock_wdg


### PR DESCRIPTION
Fix:
- when opening the widgets for the first time, the `napari` `QDockWidget` option `_close_button=False` didn't have any effect and the close button was still there. This fixes the problem (see images below).

- make the `PropertyBrowser` a floating dockwidget instead of automatically docking it when opened (see images below).

- add a toolbar second line since everything is becoming too packed in one line (mostly when a user will have more that the two shutters that we use in test config) (see images below)

---
<img width="302" alt="Screen Shot 2023-01-19 at 10 35 26 PM" src="https://user-images.githubusercontent.com/70725613/213612913-edaf070d-f0b8-488e-bec0-2ea21c921731.png">
<img width="302" alt="Screen Shot 2023-01-19 at 10 35 04 PM" src="https://user-images.githubusercontent.com/70725613/213612933-43c7bb15-0c92-42a4-a587-b0caecd31287.png">

---
<img width="1680" alt="Screen Shot 2023-01-19 at 10 45 04 PM" src="https://user-images.githubusercontent.com/70725613/213613278-ddfc6384-a753-4cfb-9be0-06a802a4b722.png">

