### PR TITLE
fix: fix warning on private access

### DIFF
--- a/src/napari_micromanager/main_window.py
+++ b/src/napari_micromanager/main_window.py
@@ -36,7 +36,6 @@ class MainWindow(MicroManagerToolbar):
 
         # get global CMMCorePlus instance
         self._mmc = CMMCorePlus.instance()
-        self.viewer = viewer
 
         self._mda_handler = _NapariMDAHandler(self._mmc, viewer)
         self.streaming_timer: QTimer | None = None


### PR DESCRIPTION
closes #241

@ianhi, this is sufficient to get rid of that warning (I can explain offline why).  all the other stuff there, including the recursion error, is indeed just napari not yet supporting python 3.11