### PR TITLE
feat: use another thread to write to mda zarr

### DIFF
--- a/src/napari_micromanager/_mda_handler.py
+++ b/src/napari_micromanager/_mda_handler.py
@@ -195,7 +195,6 @@ class _NapariMDAHandler:
             layer: Image = self.viewer.layers[layer_name]
             if not layer.visible:
                 layer.visible = True
-            layer.reset_contrast_limits()
 
     def _on_mda_finished(self, sequence: MDASequence) -> None:
         # Save layer and add increment to save name.

--- a/src/napari_micromanager/_mda_handler.py
+++ b/src/napari_micromanager/_mda_handler.py
@@ -198,9 +198,9 @@ class _NapariMDAHandler:
         # Save layer and add increment to save name.
         self._mda_running = False
         if (meta := sequence.metadata.get(SEQUENCE_META_KEY)) is not None:
-            # TODO: make sure io thread finishes before saving
-            # thread workers don't seem to have .join method?
-            # self._io_t.join()
+            # this should be ok because we fully empty the deck before this
+            # saving. Also in the future below will be removed in favor of
+            # proper writer infrastructure.
             sequence = cast("ActiveMDASequence", sequence)
             save_sequence(sequence, self.viewer.layers, meta)
 

--- a/src/napari_micromanager/_mda_handler.py
+++ b/src/napari_micromanager/_mda_handler.py
@@ -172,7 +172,7 @@ class _NapariMDAHandler:
             return
 
         # get info about the layer we need to update
-        _id, im_idx, layer_name = _id_idx_layer(event)
+        _id, im_idx, layer_name = _id_idx_layer(event)  # type: ignore
         # update the zarr array backing the layer
         self._tmp_arrays[_id][0][im_idx] = image
 
@@ -316,7 +316,7 @@ def _id_idx_layer(event: ActiveMDAEvent) -> tuple[str, tuple[int, ...], str]:
 
     Parameters
     ----------
-    event : ActiveMDAEvent
+    event : MDAEvent
         An event for which to retrieve the id, index, and layer name.
 
 

--- a/src/napari_micromanager/_mda_handler.py
+++ b/src/napari_micromanager/_mda_handler.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import contextlib
 import tempfile
-from collections import defaultdict
+from collections import defaultdict, deque
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Sequence, cast
 
 import napari
 import zarr
 from napari.experimental import link_layers, unlink_layers
-from superqt.utils import ensure_main_thread
+from pymmcore_plus import CMMCorePlus
+from superqt.utils import create_worker, ensure_main_thread
+from useq import MDAEvent, MDASequence
 
 from ._mda_meta import SEQUENCE_META_KEY, SequenceMeta
 from ._saving import save_sequence
@@ -72,6 +74,7 @@ class _NapariMDAHandler:
 
         # mapping of id -> (zarr.Array, temporary directory) for each layer created
         self._tmp_arrays: dict[str, tuple[zarr.Array, tempfile.TemporaryDirectory]] = {}
+        self._deck: deque = deque()
 
         # Add all core connections to this list.  This makes it easy to disconnect
         # from core when this widget is closed.
@@ -132,13 +135,34 @@ class _NapariMDAHandler:
         for i in self.viewer.layers:
             if i.metadata.get("uid") == sequence.uid:
                 self._mmc.mda.toggle_pause()
-                return
 
-    @ensure_main_thread  # type: ignore [misc]
-    def _on_mda_frame(self, image: np.ndarray, event: ActiveMDAEvent) -> None:
-        """Process on the `frameReady` event from the core."""
-        meta = event.sequence.metadata.get(SEQUENCE_META_KEY)
-        if meta is None:
+        self._mda_running = True
+        # init index will always be less than any event index
+        self._largest_idx: tuple[int, ...] = (-1,)
+        self._io_t = create_worker(self._watch_mda, _start_thread=True)
+
+    def _watch_mda(self) -> None:
+        print("starting to watch")
+        while self._mda_running:
+            try:
+                self._process_frame(*self._deck.pop())
+            except IndexError:
+                pass
+        import time
+
+        time.sleep(0.5)
+        # Add any images earlier images we may have skipped for performance
+        while self._deck:
+            self._process_frame(*self._deck.pop())
+
+    def _on_mda_frame(self, image: np.ndarray, event: MDAEvent) -> None:
+        """Add the newest frame to the deck."""
+        self._deck.append((image, event))
+
+    def _process_frame(self, image: np.ndarray, event: MDAEvent) -> None:
+        seq_meta = getattr(event.sequence, "metadata", None)
+        if not (seq_meta and seq_meta.get(SEQUENCE_META_KEY)):
+            # this is not an MDA we started
             return
 
         # get info about the layer we need to update
@@ -148,11 +172,21 @@ class _NapariMDAHandler:
 
         # move the viewer step to the most recently added image
         # this seems to work better than self.viewer.dims.set_point(a, v)
-        cs = list(self.viewer.dims.current_step)
-        for a, v in enumerate(im_idx):
-            cs[a] = v
-        self.viewer.dims.current_step = tuple(cs)
 
+        if im_idx > self._largest_idx:
+            self._largest_idx = im_idx
+            # Processing the most recent event
+            # update the viewer in the main thread
+            cs = list(self.viewer.dims.current_step)
+            for a, v in enumerate(im_idx):
+                cs[a] = v
+            self._update_viewer_dims(cs, layer_name, event)
+
+    @ensure_main_thread  # type: ignore [misc]
+    def _update_viewer_dims(
+        self, step: tuple, layer_name: str, event: ActiveMDAEvent
+    ) -> None:
+        self.viewer.dims.current_step = step
         meta = event.sequence.metadata["napari_mm_sequence_meta"]
         if meta.mode == "explorer" and meta.translate_explorer:
             self._translate_explorer_layer(layer_name, event)
@@ -161,11 +195,15 @@ class _NapariMDAHandler:
             layer: Image = self.viewer.layers[layer_name]
             if not layer.visible:
                 layer.visible = True
-            # layer.reset_contrast_limits()
+            layer.reset_contrast_limits()
 
     def _on_mda_finished(self, sequence: MDASequence) -> None:
         # Save layer and add increment to save name.
+        self._mda_running = False
         if (meta := sequence.metadata.get(SEQUENCE_META_KEY)) is not None:
+            # TODO: make sure io thread finishes before saving
+            # thread workers don't seem to have .join method?
+            # self._io_t.join()
             sequence = cast("ActiveMDASequence", sequence)
             save_sequence(sequence, self.viewer.layers, meta)
 

--- a/src/napari_micromanager/_mda_handler.py
+++ b/src/napari_micromanager/_mda_handler.py
@@ -142,7 +142,6 @@ class _NapariMDAHandler:
         self._io_t = create_worker(self._watch_mda, _start_thread=True)
 
     def _watch_mda(self) -> None:
-        print("starting to watch")
         while self._mda_running:
             try:
                 self._process_frame(*self._deck.pop())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ MDAS = [
     for t, z, c in itertools.product(TIME_PLANS, Z_PLANS, CHANNEL_PLANS)
 ]
 MDA_IDS = [
-    f"nT={t and len(t)}-nZ={z and len(z)}-nC={len(c)}"
+    f"nT={t and t.num_timepoints()}-nZ={z and z.num_positions()}-nC={len(c)}"
     for t, z, c in itertools.product(TIME_PLANS, Z_PLANS, CHANNEL_PLANS)
 ]
 

--- a/tests/test_layer_scale.py
+++ b/tests/test_layer_scale.py
@@ -38,6 +38,7 @@ def test_layer_scale(
 
     # cleanup zarr resources
     handler._cleanup()
+    handler._on_mda_finished(sequence)
 
     # now pretend that the user never provided a pixel size config
     # we need to not crash in this case
@@ -52,9 +53,11 @@ def test_layer_scale(
         mmc.setPixelSizeUm(pix_size)
         # cleanup zarr resources
         handler._cleanup()
+        handler._on_mda_finished(sequence)
         raise e
     # cleanup zarr resources
     handler._cleanup()
+    handler._on_mda_finished(sequence)
 
 
 def test_preview_scale(core: CMMCorePlus, main_window: MainWindow):


### PR DESCRIPTION
Fixes: https://github.com/pymmcore-plus/napari-micromanager/issues/256

Untested because i'm not yet sure this is the fully correct way to do this. Would be great to get some eyes on this from @tlambert03 and @fdrgsp 

This tries to do as much of the work of processing an MDA frame in a third thread as possible. I also wanted to ensure that the most recently captured image is the most recently displayed, so this end `deque` for its LIFO behavior and because it is higher performance than queue (https://bugs.python.org/issue15329#msg199368). 

Then when the worker thread has a chance it processes all the previous indices that it didn't get a chance to deal with before a new image came in. This is the source of the complexity of checking `_largest_idx`


To user test:

1. Open napari-micromanager 
2. Load the demo config
3. Set up MDA with one channel - 100 time points at 0 interval
4. run - check that gui is functional