### PR TITLE
fix: don't leave scale undefined

### DIFF
--- a/src/napari_micromanager/_mda_handler.py
+++ b/src/napari_micromanager/_mda_handler.py
@@ -201,6 +201,9 @@ class _NapariMDAHandler:
                 if meta.split_channels and sequence.used_axes.find("c") < index:
                     index -= 1
                 scale[index] = getattr(sequence.z_plan, "step", 1)
+        else:
+            # return to default
+            scale = [1.0, 1.0]
 
         return self.viewer.add_image(
             arr,

--- a/tests/test_layer_scale.py
+++ b/tests/test_layer_scale.py
@@ -35,6 +35,23 @@ def test_layer_scale(
     # cleanup zarr resources
     handler._cleanup()
 
+    # now pretend that the user never provided a pixel size config
+    # we need to not crash in this case
+
+    pix_size = mmc.getPixelSizeUm()
+    mmc.setPixelSizeUm("Res20x", 0)
+
+    try:
+        handler._on_mda_started(sequence)
+    except Exception as e:
+        # return to orig value for future tests and re-raise
+        mmc.setPixelSizeUm(pix_size)
+        # cleanup zarr resources
+        handler._cleanup()
+        raise e
+    # cleanup zarr resources
+    handler._cleanup()
+
 
 def test_preview_scale(core: CMMCorePlus, main_window: MainWindow):
     """Basic test to check that the main window can be created.


### PR DESCRIPTION
Follow up to #244 in which I fixed one bug, but introduced another