### PR TITLE
fix: minor fix IlluminationWidget

### DIFF
--- a/src/napari_micromanager/_gui_objects/_illumination_widget.py
+++ b/src/napari_micromanager/_gui_objects/_illumination_widget.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from pymmcore_plus import CMMCorePlus, PropertyType
 from pymmcore_widgets import PropertiesWidget
+from qtpy.QtWidgets import QSizePolicy
 
 if TYPE_CHECKING:
     from qtpy.QtWidgets import QWidget
@@ -24,3 +25,5 @@ class IlluminationWidget(PropertiesWidget):
             parent=parent,
             mmcore=mmcore,
         )
+
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)


### PR DESCRIPTION
This PR adds a `QSizePolicy` to the `IlluminationWidget`.

___
![Untitled](https://github.com/pymmcore-plus/napari-micromanager/assets/70725613/b8219013-9269-4bfa-b855-489130034163)
