### PR TITLE
test: change main_window_mda test

### DIFF
--- a/tests/test_multid_widget.py
+++ b/tests/test_multid_widget.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import numpy as np
 from napari_micromanager._gui_objects._mda_widget import MultiDWidget
 from napari_micromanager._mda_meta import SEQUENCE_META_KEY, SequenceMeta
 from pymmcore_plus.mda import MDAEngine
@@ -25,14 +24,7 @@ def test_main_window_mda(main_window: MainWindow):
         metadata={SEQUENCE_META_KEY: SequenceMeta(mode="mda")},
     )
 
-    mmc = main_window._mmc
-
-    mmc.mda.events.sequenceStarted.emit(mda)
-
-    img_shape = (mmc.getImageWidth(), mmc.getImageHeight())
-    for event in mda:
-        frame = np.random.rand(*img_shape)
-        mmc.mda.events.frameReady.emit(frame, event)
+    main_window._mmc.mda.run(mda)
     assert main_window.viewer.layers[-1].data.shape == (4, 2, 4, 512, 512)
 
 


### PR DESCRIPTION
this changes the way one of the tests works (rather than manually emitting just the right signals, it just runs the mda)