### PR TITLE
build: bump superqt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "napari >=0.4.13",
     "pymmcore-plus >=0.8.0",
     "pymmcore-widgets >=0.4.1",
-    "superqt >=0.3.1",
+    "superqt >=0.5.1",
     "tifffile",
     "useq-schema >=0.4.1",
     "zarr",


### PR DESCRIPTION
This bumps the superqt dependency to take advantage of https://github.com/pyapp-kit/superqt/pull/185, which is necessary for https://github.com/pymmcore-plus/pymmcore-plus/pull/246 to work without breaking napari-micro