### PR TITLE
fix: ObjectivesToolBar

### DIFF
--- a/src/napari_micromanager/_gui_objects/_toolbar.py
+++ b/src/napari_micromanager/_gui_objects/_toolbar.py
@@ -234,16 +234,7 @@ class ObjectivesToolBar(MMToolBar):
     def __init__(self, parent: QWidget) -> None:
         super().__init__("Objectives", parent=parent)
         self._wdg = ObjectivesWidget()
-        self._wdg._mmc.events.systemConfigurationLoaded.connect(self._resize_obj)
         self.addSubWidget(self._wdg)
-        self._resize_obj()
-
-    def _resize_obj(self) -> None:
-        self._wdg._combo.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
-        )
-        self._wdg.setMinimumWidth(0)
-        self._wdg._combo.adjustSize()
 
 
 class ChannelsToolBar(MMToolBar):


### PR DESCRIPTION
This is related to #288 

merge after https://github.com/pymmcore-plus/pymmcore-widgets/pull/196

In this PR we are removing the `ObjectivesToolBar` `_resize_obj()` method and we moved it directly to `pymmocre-widgets`  `ObjectivesWidget()` (https://github.com/pymmcore-plus/pymmcore-widgets/pull/196). This should fix the issue found in #288  since resizing is performed directly when the combo is created.

closes #288.