### PR TITLE
feat: add `mmcore` to viewer console namespace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,13 +12,13 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.1.9
     hooks:
       - id: ruff
         args: [--fix]
 
   - repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 23.12.1
     hooks:
       - id: black
 
@@ -28,7 +28,7 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
+    rev: v1.8.0
     hooks:
       - id: mypy
         files: "^src/"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ GUI interface between napari and micromanager powered by [pymmcore-plus](https:/
 You can install `napari-micromanager` via [pip]:
 
     pip install napari-micromanager
+    
+You will also need a Qt backend such as PySide2/6, or PyQt5/6.  If you've previously installed napari
+into this environment with `pip install napari[all]`, then you will likely already have it. If not,
+you will also need to install a Qt backend of your choice:
+
+    pip install pyqt5  # or any of {pyqt5, pyqt6, pyside2, pyside6} 
 
 ### Getting micromanager adapters:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ filterwarnings = [
     "ignore::DeprecationWarning:ipykernel",
     "ignore:<tifffile.TiffWriter.write> data with shape:DeprecationWarning:", # for napari
     "ignore:`np.bool8` is a deprecated alias::skimage",
+    "ignore::DeprecationWarning:pandas",
 ]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,8 @@ filterwarnings = [
     "ignore::DeprecationWarning:ipykernel",
     "ignore:<tifffile.TiffWriter.write> data with shape:DeprecationWarning:", # for napari
     "ignore:`np.bool8` is a deprecated alias::skimage",
-    "ignore::DeprecationWarning:pandas",
+    "ignore:Jupyter is migrating its paths to use standard platformdirs:",
+    "ignore:\\nPyarrow will become a required dependency"
 ]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html

--- a/src/napari_micromanager/_gui_objects/_toolbar.py
+++ b/src/napari_micromanager/_gui_objects/_toolbar.py
@@ -66,6 +66,18 @@ class MicroManagerToolbar(QMainWindow):
         self._mmc = CMMCorePlus.instance()
         self.viewer: napari.viewer.Viewer = getattr(viewer, "__wrapped__", viewer)
 
+        # add variables to the napari console
+        if console := getattr(self.viewer.window._qt_viewer, "console", None):
+            from useq import MDAEvent, MDASequence
+
+            console.push(
+                {
+                    "MDAEvent": MDAEvent,
+                    "MDASequence": MDASequence,
+                    "mmcore": self._mmc,
+                }
+            )
+
         # min max widget
         self.minmax = MinMax(parent=self)
 

--- a/src/napari_micromanager/_gui_objects/_toolbar.py
+++ b/src/napari_micromanager/_gui_objects/_toolbar.py
@@ -14,10 +14,16 @@ from pymmcore_widgets import (
     GroupPresetTableWidget,
     LiveButton,
     ObjectivesWidget,
-    PixelSizeWidget,
     PropertyBrowser,
     SnapButton,
 )
+
+try:
+    # this was renamed
+    from pymmcore_widgets import ObjectivesPixelConfigurationWidget
+except ImportError:
+    from pymmcore_widgets import PixelSizeWidget as ObjectivesPixelConfigurationWidget
+
 from qtpy.QtCore import QEvent, QObject, QSize, Qt
 from qtpy.QtWidgets import (
     QDockWidget,
@@ -52,7 +58,7 @@ DOCK_WIDGETS: Dict[str, Tuple[type[QWidget], str | None]] = {  # noqa: U006
     "Illumination Control": (IlluminationWidget, MDI6.lightbulb_on),
     "Stages Control": (MMStagesWidget, MDI6.arrow_all),
     "Camera ROI": (CameraRoiWidget, MDI6.crop),
-    "Pixel Size Table": (PixelSizeWidget, MDI6.ruler),
+    "Pixel Size Table": (ObjectivesPixelConfigurationWidget, MDI6.ruler),
     "MDA": (MultiDWidget, None),
 }
 


### PR DESCRIPTION
this PR adds the name `mmcore` to the console in napari once the plugin has been activated, so you no longer need to grab `mmcore = CMMCorePlus.instance()`, you can immediately use `mmcore`, as well as `MDASequence` and `MDAEvent`

cc @linshaova ... this would make your usage slightly easier

closes #253