### PR TITLE
fix: fix zarr dtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ GUI interface between napari and micromanager powered by [pymmcore-plus](https:/
 You can install `napari-micromanager` via [pip]:
 
     pip install napari-micromanager
-    
+
 You will also need a Qt backend such as PySide2/6, or PyQt5/6.  If you've previously installed napari
 into this environment with `pip install napari[all]`, then you will likely already have it. If not,
 you will also need to install a Qt backend of your choice:
 
-    pip install pyqt5  # or any of {pyqt5, pyqt6, pyside2, pyside6} 
+    pip install pyqt5  # or any of {pyqt5, pyqt6, pyside2, pyside6}
 
 ### Getting micromanager adapters:
 

--- a/src/napari_micromanager/_mda_handler.py
+++ b/src/napari_micromanager/_mda_handler.py
@@ -135,7 +135,7 @@ class _NapariMDAHandler:
         # now create a zarr array in a temporary directory for each layer
         for id_, shape, kwargs in layers_to_create:
             tmp = tempfile.TemporaryDirectory()
-            dtype = f"uint{self._mmc.getImageBitDepth()}"
+            dtype = f"u{self._mmc.getBytesPerPixel()}"
             # create the zarr array and add it to the viewer
             z = zarr.open(
                 str(tmp.name),


### PR DESCRIPTION
To set the zarr dtype, use `getBytesPerPixel`  instead of  `getImageBitDepth` but get this info from using `getBytesPerPixel` 

closes #295