### PR TITLE
Show output from any pymmcore-plus MDA in napari viewer

### DIFF
--- a/src/napari_micromanager/_mda_handler.py
+++ b/src/napari_micromanager/_mda_handler.py
@@ -119,8 +119,8 @@ class _NapariMDAHandler:
 
         if meta is None:
             # this is not an MDA we started
-            # TODO: should we still handle this with some sane defaults?
-            return
+            # so just use the default napari_mm metadata
+            meta = sequence.metadata[SEQUENCE_META_KEY] = SequenceMeta()
         sequence = cast("ActiveMDASequence", sequence)
 
         # pause acquisition until zarr layer(s) are added


### PR DESCRIPTION
this makes it so that even if napari-micromanager didn't start the MDA, any MDA running in the currently monitored CMMCorePlus instance will be shown in the viewer.  Closes #305 

There are still places where bugs could potentially happen if frameReady somehow got emitted without sequenceStarted being emitted (not sure how that would happen), but those latent bugs have always been there