### PR TITLE
fix: fix error when loading SequenceMeta as dict

### DIFF
--- a/src/napari_micromanager/_gui_objects/_mda_widget.py
+++ b/src/napari_micromanager/_gui_objects/_mda_widget.py
@@ -49,7 +49,7 @@ class MultiDWidget(MDAWidget):
             split_channels=bool(split),
             save_dir=widget_meta.get("save_dir", ""),
             file_name=widget_meta.get("save_name", ""),
-            should_save="save_dir" in widget_meta,
+            should_save=bool("save_dir" in widget_meta),
         )
         return sequence  # type: ignore[no-any-return]
 
@@ -58,11 +58,14 @@ class MultiDWidget(MDAWidget):
         if nmm_meta := value.metadata.get(SEQUENCE_META_KEY):
             if isinstance(nmm_meta, dict):
                 nmm_meta = SequenceMeta(**nmm_meta)
+            if not isinstance(nmm_meta, SequenceMeta):  # pragma: no cover
+                raise TypeError(f"Expected {SequenceMeta}, got {type(nmm_meta)}")
 
             # update pymmcore_widgets metadata if SequenceMeta are provided
             widgets_meta = value.metadata.setdefault(MMCORE_WIDGETS_META, {})
             widgets_meta.setdefault("save_dir", nmm_meta.save_dir)
             widgets_meta.setdefault("save_name", nmm_meta.file_name)
+
             # set split_channels checkbox
             self.checkBox_split_channels.setChecked(bool(nmm_meta.split_channels))
         super().setValue(value)

--- a/src/napari_micromanager/_gui_objects/_mda_widget.py
+++ b/src/napari_micromanager/_gui_objects/_mda_widget.py
@@ -49,21 +49,20 @@ class MultiDWidget(MDAWidget):
             split_channels=bool(split),
             save_dir=widget_meta.get("save_dir", ""),
             file_name=widget_meta.get("save_name", ""),
-            should_save=bool("save_dir" in widget_meta),
+            should_save="save_dir" in widget_meta,
         )
         return sequence  # type: ignore[no-any-return]
 
     def setValue(self, value: MDASequence) -> None:
         """Set the current value of the widget."""
         if nmm_meta := value.metadata.get(SEQUENCE_META_KEY):
-            if not isinstance(nmm_meta, SequenceMeta):  # pragma: no cover
-                raise TypeError(f"Expected {SequenceMeta}, got {type(nmm_meta)}")
+            if isinstance(nmm_meta, dict):
+                nmm_meta = SequenceMeta(**nmm_meta)
 
             # update pymmcore_widgets metadata if SequenceMeta are provided
             widgets_meta = value.metadata.setdefault(MMCORE_WIDGETS_META, {})
             widgets_meta.setdefault("save_dir", nmm_meta.save_dir)
             widgets_meta.setdefault("save_name", nmm_meta.file_name)
-
             # set split_channels checkbox
             self.checkBox_split_channels.setChecked(bool(nmm_meta.split_channels))
         super().setValue(value)

--- a/tests/test_multid_widget.py
+++ b/tests/test_multid_widget.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
 from napari_micromanager._gui_objects._mda_widget import MultiDWidget
 from napari_micromanager._mda_meta import SEQUENCE_META_KEY, SequenceMeta
 from pymmcore_plus.mda import MDAEngine
@@ -76,12 +75,7 @@ def test_saving_mda(
     expected_shape = [x for x in (*mda.shape, 500, 512) if x > 1]
 
     multiC = len(mda.channels) > 1
-
-    meta = mda.metadata[SEQUENCE_META_KEY]
-    if isinstance(meta, dict):
-        meta = SequenceMeta(**meta)
-
-    splitC = meta.split_channels
+    splitC = mda.metadata[SEQUENCE_META_KEY].split_channels
     if multiC and splitC:
         expected_shape.pop(mda.used_axes.find("c"))
         nfiles = len(list((tmp_path / f"{meta.file_name}_000").iterdir()))
@@ -112,26 +106,3 @@ def test_script_initiated_mda(main_window: MainWindow, qtbot: QtBot):
     viewer_layer_names = [layer.name for layer in viewer.layers]
     assert layer_name in viewer_layer_names
     assert sequence.shape == viewer.layers[layer_name].data.shape[:-2]
-
-
-meta = [
-    {SEQUENCE_META_KEY: SequenceMeta(mode="mda")},
-    {SEQUENCE_META_KEY: {"mode": "mda"}},
-]
-
-
-@pytest.mark.parametrize("meta", meta)
-def test_mda_set_value(qtbot: QtBot, meta: dict[str, str]):
-    wdg = MultiDWidget()
-    qtbot.addWidget(wdg)
-
-    sequence = MDASequence(
-        channels=[{"config": "Cy5", "exposure": 1}],
-        time_plan={"interval": 0.1, "loops": 2},
-        axis_order="pcz",
-        stage_positions=[(222, 1, 1)],
-        metadata=meta,
-    )
-    wdg.setValue(sequence)
-
-    assert wdg.value().metadata[SEQUENCE_META_KEY].mode == "mda"


### PR DESCRIPTION
fix `SequenceMeta` /`dict` error in tests not passing both locally and in in #309: `FAILED tests/test_multid_widget.py::test_saving_mda[splitC-nT=0-nZ=0-nC=1] - AttributeError: 'dict' object has no attribute 'split_channels'
`

note: new test added