### PR TITLE
test: small fix to test

### DIFF
--- a/tests/test_multid_widget.py
+++ b/tests/test_multid_widget.py
@@ -53,8 +53,10 @@ def test_saving_mda(
     assert mda_widget.save_info.isChecked()
     meta = mda_widget.value().metadata[SEQUENCE_META_KEY]
     assert meta.save_dir == str(tmp_path)
-    mda = mda.replace(axis_order=mda_widget.value().axis_order)
-
+    # using `metadata=mda.metadata` here to keep the SequenceMeta object
+    # rather than a serialized dict... this is a hack to get around a broader issue
+    # with the .replace method
+    mda = mda.replace(axis_order=mda_widget.value().axis_order, metadata=mda.metadata)
     mmc = main_window._mmc
 
     # re-register twice to fully exercise the logic of the update


### PR DESCRIPTION
this fixes a small issue in one of the tests.  Not sure why it hasn't been failing on ci:

the `MDASequence.replace()` method will serialize all objects, including metadata... meaning it may turn a `SequenceMeta()` object into a dict... that's a broader issue that needs examining, but this is just a local workaround