### PR TITLE
fix: prevent preview update when mda is running

### DIFF
--- a/src/napari_micromanager/_core_link.py
+++ b/src/napari_micromanager/_core_link.py
@@ -35,7 +35,7 @@ class CoreViewerLink(QObject):
         # Add all core connections to this list.  This makes it easy to disconnect
         # from core when this widget is closed.
         self._connections: list[tuple[PSignalInstance, Callable]] = [
-            (self._mmc.events.imageSnapped, self._update_viewer),
+            (self._mmc.events.imageSnapped, self._image_snapped),
             (self._mmc.events.imageSnapped, self._stop_live),
             (self._mmc.events.continuousSequenceAcquisitionStarted, self._start_live),
             (self._mmc.events.sequenceAcquisitionStopped, self._stop_live),
@@ -53,6 +53,12 @@ class CoreViewerLink(QObject):
 
     def timerEvent(self, a0: QTimerEvent | None) -> None:
         self._update_viewer()
+
+    def _image_snapped(self) -> None:
+        # If we are in the middle of an MDA, don't update the preview viewer.
+        if self._mda_handler._mda_running:
+            return
+        self._update_viewer(self._mmc.getImage())
 
     def _start_live(self) -> None:
         interval = int(self._mmc.getExposure())

--- a/src/napari_micromanager/_core_link.py
+++ b/src/napari_micromanager/_core_link.py
@@ -56,9 +56,8 @@ class CoreViewerLink(QObject):
 
     def _image_snapped(self) -> None:
         # If we are in the middle of an MDA, don't update the preview viewer.
-        if self._mda_handler._mda_running:
-            return
-        self._update_viewer(self._mmc.getImage())
+        if not self._mda_handler._mda_running:
+            self._update_viewer(self._mmc.getImage())
 
     def _start_live(self) -> None:
         interval = int(self._mmc.getExposure())

--- a/src/napari_micromanager/_mda_handler.py
+++ b/src/napari_micromanager/_mda_handler.py
@@ -87,6 +87,7 @@ class _NapariMDAHandler:
     def __init__(self, mmcore: CMMCorePlus, viewer: napari.viewer.Viewer) -> None:
         self._mmc = mmcore
         self.viewer = viewer
+        self._mda_running: bool = False
 
         # mapping of id -> (zarr.Array, temporary directory) for each layer created
         self._tmp_arrays: dict[str, tuple[zarr.Array, tempfile.TemporaryDirectory]] = {}

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
+import useq
 from napari_micromanager.main_window import MainWindow
 
 if TYPE_CHECKING:
@@ -29,3 +30,18 @@ def test_main_window(qtbot: QtBot, core: CMMCorePlus) -> None:
 
     wdg._cleanup()
     viewer.layers.events.disconnect.assert_called_once_with(wdg._update_max_min)
+
+
+def test_preview_while_mda(main_window: MainWindow, qtbot: QtBot):
+    # we should show the mda even if it came from outside
+    mmc = main_window._mmc
+    viewer = main_window.viewer
+
+    # make sure that preview is not updated during MDA
+    seq = useq.MDASequence(channels=["FITC"])
+
+    with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
+        mmc.run_mda(seq)
+
+    layers = [layer.name for layer in viewer.layers]
+    assert "preview" not in layers


### PR DESCRIPTION
Necessary after https://github.com/pymmcore-plus/pymmcore-plus/pull/314

- use the new core.events.imageSnapped
- when a MDA is running, we don't want to update the image preview layer (since we're already updating the active experiment layers)
- add test
