### PR TITLE
fix: fix when passing a config file in the command line

### DIFF
--- a/src/napari_micromanager/__main__.py
+++ b/src/napari_micromanager/__main__.py
@@ -10,7 +10,7 @@ from typing import Sequence
 def main(args: Sequence[str] | None = None) -> None:
     """Create a napari viewer and add the MicroManager plugin to it."""
     if args is None:
-        args = sys.argv
+        args = sys.argv[1:]
 
     parser = argparse.ArgumentParser(description="Enter string")
     parser.add_argument(


### PR DESCRIPTION
currently if we try to run 

`napari-micromanager -c "test_config.cfg"` (or `python -m napari_micromanager`) 

we get an `unrecognized arguments` error.

I think it's because the `main()` function in `__main__.py` is considering `.../napari-micromanager/src/napari_micromanager` (or `.../napari-micromanager/src/napari_micromanager__main__.py` as the first argument.  

This PR fixes that issue.