### PR TITLE
docs: update image in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 GUI interface between napari and micromanager powered by [pymmcore-plus](https://pymmcore-plus.github.io/pymmcore-plus/) and [pymmcore-widgets](https://pymmcore-plus.github.io/pymmcore-widgets/)
 
 ----------------------------------
-<img width="1797" alt="mm" src="https://user-images.githubusercontent.com/1609449/138457506-787b7bec-7f30-4d92-b5cf-6e218c87225a.png">
+![napari-micromanager](./napari-micromanager.png)
 
 
 ## Installation


### PR DESCRIPTION
Update the `napari-micromanager` image in the docs to the recent version.