### PR TITLE
fix: Prevent lots of 'circular buffer empty' errors in MM

### DIFF
--- a/src/napari_micromanager/_core_link.py
+++ b/src/napari_micromanager/_core_link.py
@@ -77,6 +77,8 @@ class CoreViewerLink(QObject):
     def _update_viewer(self, data: np.ndarray | None = None) -> None:
         """Update viewer with the latest image from the circular buffer."""
         if data is None:
+            if self._mmc.getRemainingImageCount() == 0:
+                return
             try:
                 data = self._mmc.getLastImage()
             except (RuntimeError, IndexError):


### PR DESCRIPTION
Trying to read from an empty circular buffer causes lots of error messages in MM error log. Prevent them.