### PR TITLE
fix: Add support to set illumination level for Lumencor devices

### DIFF
--- a/src/napari_micromanager/_gui_objects/_illumination_widget.py
+++ b/src/napari_micromanager/_gui_objects/_illumination_widget.py
@@ -20,7 +20,7 @@ class IlluminationWidget(PropertiesWidget):
         mmcore: CMMCorePlus | None = None,
     ):
         super().__init__(
-            property_name_pattern="(Intensity|Power|test)s?",
+            property_name_pattern="(Intensity|Power|Level|test)s?",
             property_type={PropertyType.Integer, PropertyType.Float},
             parent=parent,
             mmcore=mmcore,


### PR DESCRIPTION
This PR provides a quick fix for Lumencor devices.

In Lumencor LED lamps, the power level is controlled via the property attribute Level (e.g., Red_Level). By including the term Level in the property_name_pattern of the illumination widget, the LED power can now be set directly from the illumination widget.
Tested on a Spectra X.
Thank you very much for your hard work on pymmcore-plus, as well as on this project, napari-micromanager. 