### PR TITLE
fix: replace deprecated toggle_pause() with set_paused()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install "mypy==1.18.2" useq-schema pymmcore_plus
+      # temporary: override pymmcore-plus with set_paused() until next release
+      - run: pip install --no-deps "pymmcore-plus @ git+https://github.com/pymmcore-plus/pymmcore-plus.git@main"
       - run: mypy src
 
   test:
@@ -65,6 +67,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[test,${{ matrix.backend }}]
+
+      # temporary: override pymmcore-plus with set_paused() until next release
+      - name: Override pymmcore-plus
+        run: python -m pip install --no-deps "pymmcore-plus @ git+https://github.com/pymmcore-plus/pymmcore-plus.git@main"
 
       - name: Set cache path
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-latest, macos-15-intel]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         backend: [pyqt5]
         include:
           - python-version: "3.11"

--- a/src/napari_micromanager/_mda_handler.py
+++ b/src/napari_micromanager/_mda_handler.py
@@ -96,7 +96,7 @@ class _NapariMDAHandler:
             return
 
         # pause acquisition until zarr layer(s) are added
-        self._mmc.mda.toggle_pause()  # TODO: can we remove this somewhow?
+        self._mmc.mda.set_paused(True)
 
         # determine the new layers that need to be created for this experiment
         # (based on the sequence mode, and whether we're splitting C/P, etc.)
@@ -142,7 +142,7 @@ class _NapariMDAHandler:
         self._reset_viewer_dims()
 
         # resume acquisition after zarr layer(s) is(are) added
-        self._mmc.mda.toggle_pause()
+        self._mmc.mda.set_paused(False)
 
     def _watch_mda(
         self,


### PR DESCRIPTION
https://github.com/pymmcore-plus/pymmcore-plus/pull/517 deprecated `MDARunner.toggle_pause()` in favor of `set_paused(bool)`. Also removed Python 3.9 from tests, as pymmcore-plus is not compatible with it.
TODO:
- point tests at release instead of git main, once the change is merged
- also change deps of napari-micromanager to match python version requirements of pymmcore-plus?