### PR TITLE
fix: prevent MDA handler callbacks from firing after viewer teardown

### DIFF
--- a/src/napari_micromanager/_core_link.py
+++ b/src/napari_micromanager/_core_link.py
@@ -31,6 +31,7 @@ class CoreViewerLink(QObject):
         self.viewer = viewer
         self._mda_handler = _NapariMDAHandler(self._mmc, viewer)
         self._live_timer_id: int | None = None
+        self._mda_poll_timer_id: int | None = None
 
         # Add all core connections to this list.  This makes it easy to disconnect
         # from core when this widget is closed.
@@ -41,11 +42,15 @@ class CoreViewerLink(QObject):
             (self._mmc.events.sequenceAcquisitionStopped, self._stop_live),
             (self._mmc.events.exposureChanged, self._restart_live),
             (self._mmc.events.configSet, self._restart_live),
+            (self._mmc.mda.events.sequenceStarted, self._start_mda_poll),
+            (self._mmc.mda.events.sequenceFinished, self._stop_mda_poll),
         ]
         for signal, slot in self._connections:
             signal.connect(slot)
 
     def cleanup(self) -> None:
+        self._stop_live()
+        self._stop_mda_poll()
         for signal, slot in self._connections:
             with contextlib.suppress(TypeError, RuntimeError):
                 signal.disconnect(slot)
@@ -53,7 +58,24 @@ class CoreViewerLink(QObject):
         self._mda_handler._cleanup()
 
     def timerEvent(self, a0: QTimerEvent | None) -> None:
-        self._update_viewer()
+        if a0 is not None and a0.timerId() == self._mda_poll_timer_id:
+            self._poll_mda_updates()
+        else:
+            self._update_viewer()
+
+    def _start_mda_poll(self, *_: object) -> None:
+        if self._mda_poll_timer_id is None:
+            self._mda_poll_timer_id = self.startTimer(50, Qt.TimerType.PreciseTimer)
+
+    def _stop_mda_poll(self, *_: object) -> None:
+        if self._mda_poll_timer_id is not None:
+            self.killTimer(self._mda_poll_timer_id)
+            self._mda_poll_timer_id = None
+
+    def _poll_mda_updates(self) -> None:
+        handler = self._mda_handler
+        while handler._viewer_updates:
+            handler._update_viewer_dims(handler._viewer_updates.popleft())
 
     def _image_snapped(self) -> None:
         # If we are in the middle of an MDA, don't update the preview viewer.

--- a/src/napari_micromanager/_mda_handler.py
+++ b/src/napari_micromanager/_mda_handler.py
@@ -2,18 +2,18 @@ from __future__ import annotations
 
 import contextlib
 import tempfile
+import threading
 import time
 from collections import deque
 from typing import TYPE_CHECKING, Callable, cast
 
 import napari
 import zarr
-from superqt.utils import create_worker, ensure_main_thread
+from superqt.utils import ensure_main_thread
 
 from ._util import NMM_METADATA_KEY, PYMMCW_METADATA_KEY, get_full_sequence_axes
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
     from uuid import UUID
 
     import napari.viewer
@@ -62,6 +62,8 @@ class _NapariMDAHandler:
         # mapping of id -> (zarr.Array, temporary directory) for each layer created
         self._tmp_arrays: dict[str, tuple[zarr.Array, tempfile.TemporaryDirectory]] = {}
         self._deck: deque[tuple[np.ndarray, MDAEvent]] = deque()
+        # processed frame results for the main-thread timer to pick up
+        self._viewer_updates: deque[tuple[str | None, tuple[int, ...] | None]] = deque()
 
         # Add all core connections to this list.  This makes it easy to disconnect
         # from core when this widget is closed.
@@ -74,6 +76,7 @@ class _NapariMDAHandler:
             signal.connect(slot)
 
     def _cleanup(self) -> None:
+        self._mda_running = False  # stops the worker thread loop
         for signal, slot in self._connections:
             with contextlib.suppress(TypeError, RuntimeError):
                 signal.disconnect(slot)
@@ -82,6 +85,9 @@ class _NapariMDAHandler:
             z.store.close()
             with contextlib.suppress(NotADirectoryError):
                 v.cleanup()
+        self._tmp_arrays.clear()
+        self._deck.clear()
+        self._viewer_updates.clear()
 
     @ensure_main_thread  # type: ignore [misc]
     def _on_mda_started(self, sequence: MDASequence) -> None:
@@ -131,12 +137,9 @@ class _NapariMDAHandler:
         self._largest_idx: tuple[int, ...] = (-1,)
 
         self._deck = deque()
+        self._viewer_updates = deque()
         self._mda_running = True
-        self._io_t = create_worker(
-            self._watch_mda,
-            _start_thread=True,
-            _connect={"yielded": self._update_viewer_dims},
-        )
+        threading.Thread(target=self._frame_worker, daemon=True).start()
 
         # Set the viewer slider on the first layer frame
         self._reset_viewer_dims()
@@ -144,14 +147,12 @@ class _NapariMDAHandler:
         # resume acquisition after zarr layer(s) is(are) added
         self._mmc.mda.set_paused(False)
 
-    def _watch_mda(
-        self,
-    ) -> Generator[tuple[str | None, tuple[int, ...] | None], None, None]:
-        """Watch the MDA for new frames and process them as they come in."""
+    def _frame_worker(self) -> None:
+        """Background thread: process frames from _deck into zarr."""
         while self._mda_running:
             if self._deck:
-                layer_name, im_idx = self._process_frame(*self._deck.pop())
-                yield layer_name, im_idx
+                result = self._process_frame(*self._deck.pop())
+                self._viewer_updates.append(result)
             else:
                 time.sleep(0.1)
 
@@ -187,7 +188,6 @@ class _NapariMDAHandler:
 
         return layer_name, None
 
-    @ensure_main_thread  # type: ignore [misc]
     def _update_viewer_dims(
         self, args: tuple[str | None, tuple[int, ...] | None]
     ) -> None:
@@ -206,7 +206,6 @@ class _NapariMDAHandler:
             cs[a] = v
         self.viewer.dims.current_step = cs
 
-    @ensure_main_thread  # type: ignore [misc]
     def _reset_viewer_dims(self) -> None:
         """Reset the viewer dims to the first image."""
         self.viewer.dims.current_step = [0] * len(self.viewer.dims.current_step)


### PR DESCRIPTION
## Summary

Replace the `GeneratorWorker.yielded` → `@ensure_main_thread` → `_update_viewer_dims` cross-thread callback chain with a QTimer on `CoreViewerLink` that polls a results deque.

## Problem

During MDA acquisition, processed frames are passed from a background worker to the main thread via `@ensure_main_thread`, which uses `QMetaObject.invokeMethod(QueuedConnection)`. These callbacks are posted to the Qt event queue and execute asynchronously.

When the viewer is closed, `viewer.close()` processes the event queue while tearing down — but the queued callbacks still try to access `viewer.layers[...]`, which has already been cleared. This causes `ValueError: 'layer_name' is not in list` on teardown. The issue affects every recent CI run on `main`.

Once a `QueuedConnection` callback is dispatched, it cannot be cancelled — so the fix needs to avoid cross-thread Qt callbacks entirely.

## Solution

- Background thread processes frames into zarr and appends results to a `deque` (thread-safe under CPython)
- A 50ms QTimer on `CoreViewerLink` (main thread) polls the deque and updates the viewer
- `killTimer()` in `cleanup()` is synchronous — no callbacks can fire after it returns

The previous worker already polled `_deck` with a 100ms `time.sleep`, so the 50ms timer interval is comparable or faster. This follows the same pattern already used for live mode in `CoreViewerLink`.

## Changes

**`_mda_handler.py`**: Replace `GeneratorWorker` + `_watch_mda` generator with `threading.Thread` + `_frame_worker`. Remove `@ensure_main_thread` from `_update_viewer_dims` and `_reset_viewer_dims` (now called from main-thread timer only). Add `_viewer_updates` deque for processed results.

**`_core_link.py`**: Add MDA poll timer alongside existing live timer. Listen to `sequenceStarted`/`sequenceFinished` to start/stop polling. Dispatch in `timerEvent` based on timer ID.

## Test plan

- [x] All `test_saving_mda` variants pass (previously flaky on every CI run)
- [x] `test_layer_scale` passes (handler used directly without CoreViewerLink)
- [x] Full test suite passes — 8/8 CI jobs green (2 needed a re-run due to unrelated iconify CDN timeout and pre-existing chunk flush race)