### PR TITLE
fix: release MainWindow and CMMCorePlus on napari window close

### DIFF
--- a/src/napari_micromanager/_core_link.py
+++ b/src/napari_micromanager/_core_link.py
@@ -50,13 +50,29 @@ class CoreViewerLink(QObject):
         for signal, slot in self._connections:
             signal.connect(slot)
 
-    def cleanup(self) -> None:
-        # Stop live acquisition if running
+    def cleanup(self, owns: bool = False) -> None:
+        """Stop viewer-side activity and, when owned, tear down the core.
+
+        Parameters
+        ----------
+        owns : bool, default False
+            Whether the plugin owns the core. When True, also cancel the
+            running MDA (if any) and unload all devices. When False, leave
+            the core's MDA and devices alone — the owner is still using it.
+        """
         self._stop_live()
         self._stop_mda_poll()
         with contextlib.suppress(Exception):
-            if self._mmc.isSequenceRunning():
-                self._mmc.stopSequenceAcquisition()
+            self._mmc.stopSequenceAcquisition()
+        # MDA cancel: the runner spawns a non-daemon thread that would
+        # otherwise block interpreter shutdown and keep exclusive device
+        # handles bound. unloadAllDevices: release devices immediately
+        # rather than waiting for a non-deterministic GC of the core.
+        if owns:
+            with contextlib.suppress(Exception):
+                self._mmc.mda.cancel()
+            with contextlib.suppress(Exception):
+                self._mmc.unloadAllDevices()
 
         for signal, slot in self._connections:
             with contextlib.suppress(TypeError, RuntimeError):

--- a/src/napari_micromanager/_gui_objects/_toolbar.py
+++ b/src/napari_micromanager/_gui_objects/_toolbar.py
@@ -80,7 +80,19 @@ class MicroManagerToolbar(QMainWindow):
     ) -> None:
         super().__init__()
 
-        self._mmc = mmcore or CMMCorePlus.instance()
+        # If no core is passed in, the plugin creates its own fresh core and
+        # takes responsibility for its lifecycle (cancel MDAs, unload devices
+        # on close). Deliberately avoid `CMMCorePlus.instance()` — that would
+        # silently adopt a singleton the plugin didn't create, making
+        # ownership ambiguous. To have the plugin drive an existing core
+        # without taking ownership, pass it as `mmcore=`; the plugin will
+        # leave its lifecycle to the caller.
+        if mmcore is None:
+            self._mmc = CMMCorePlus()
+            self._owns_core = True
+        else:
+            self._mmc = mmcore
+            self._owns_core = False
         self.viewer: napari.viewer.Viewer = getattr(viewer, "__wrapped__", viewer)
 
         # add variables to the napari console

--- a/src/napari_micromanager/_gui_objects/_toolbar.py
+++ b/src/napari_micromanager/_gui_objects/_toolbar.py
@@ -48,6 +48,11 @@ from napari_micromanager._gui_objects._stages_widget import MMStagesWidget
 if TYPE_CHECKING:
     import napari.viewer
 
+# Opt out of napari-console's `_capture()` — without this, creating the console
+# below would push this module's frame (including `self`) into the IPython
+# user_ns, pinning MainWindow for the process lifetime.
+NAPARI_EMBED = True
+
 TOOL_SIZE = 35
 
 

--- a/src/napari_micromanager/_gui_objects/_toolbar.py
+++ b/src/napari_micromanager/_gui_objects/_toolbar.py
@@ -48,9 +48,13 @@ from napari_micromanager._gui_objects._stages_widget import MMStagesWidget
 if TYPE_CHECKING:
     import napari.viewer
 
-# Opt out of napari-console's `_capture()` — without this, creating the console
-# below would push this module's frame (including `self`) into the IPython
-# user_ns, pinning MainWindow for the process lifetime.
+# Opt out of napari-console's `_capture()`. This is an un/mis-documented API
+# in `napari_console.qt_console`: the napari-console README says to set an
+# environment variable `NAPARI_EMBED=1`, but the actual check in
+# `QtConsole._capture` looks for `NAPARI_EMBED` in the calling frame's module
+# globals. Without this opt-out, creating the console below would push this
+# module's frame (including the `self` local of `MicroManagerToolbar.__init__`)
+# into the IPython user_ns, pinning MainWindow for the process lifetime.
 NAPARI_EMBED = True
 
 TOOL_SIZE = 35

--- a/src/napari_micromanager/main_window.py
+++ b/src/napari_micromanager/main_window.py
@@ -75,9 +75,10 @@ class MainWindow(MicroManagerToolbar):
         self,
         viewer: napari.viewer.Viewer,
         config: str | Path | None = None,
+        mmcore: CMMCorePlus | None = None,
     ) -> None:
-        super().__init__(viewer)
-        self.set_core(self._mmc)
+        super().__init__(viewer, mmcore=mmcore)
+        self.set_core(self._mmc, owns=self._owns_core)
 
         # some remaining connections related to widgets ... TODO: unify with superclass
         self._connections: list[tuple[PSignalInstance, Callable]] = [
@@ -132,9 +133,24 @@ class MainWindow(MicroManagerToolbar):
         """The CMMCorePlus instance currently used by this window."""
         return self._mmc
 
-    def set_core(self, core: CMMCorePlus) -> None:
-        """Install *core*, tearing down the previous one if present."""
+    def set_core(self, core: CMMCorePlus, owns: bool = False) -> None:
+        """Install *core*, tearing down the previous one if present.
+
+        Parameters
+        ----------
+        core : CMMCorePlus
+            The core to install.
+        owns : bool, default False
+            Whether the plugin takes ownership of *core*. When True, the
+            plugin is responsible for its lifecycle: on viewer close (and
+            on the next ``set_core`` swap) it will cancel any running MDA
+            and unload all devices. When False, the plugin will not cancel
+            MDAs or unload devices on *core* — use this when the caller
+            retains its own reference and manages the core's lifecycle
+            itself.
+        """
         old_link = getattr(self, "_core_link", None)
+        old_owns = getattr(self, "_owns_core", False)
 
         # Guard: refuse if MDA is running
         if old_link is not None and old_link._mda_handler._mda_running:
@@ -143,12 +159,13 @@ class MainWindow(MicroManagerToolbar):
         # Tear down old core (if any)
         if old_link is not None:
             self._unwrap_load_system_configuration(self._mmc)
-            old_link.cleanup()
+            old_link.cleanup(owns=old_owns)
             old_link.setParent(None)
             old_link.deleteLater()
 
         # Install new core
         self._mmc = core
+        self._owns_core = owns
         self._core_link = CoreViewerLink(self.viewer, self._mmc, self)
         self._wrap_load_system_configuration(self._mmc)
 
@@ -187,11 +204,11 @@ class MainWindow(MicroManagerToolbar):
             is_unicore = isinstance(win._mmc, UniMMCore)
 
             if needs_unicore and not is_unicore:
-                win.set_core(UniMMCore())
+                win.set_core(UniMMCore(), owns=True)
                 win._mmc.loadSystemConfiguration(path)
                 return
             if not needs_unicore and is_unicore:
-                win.set_core(CMMCorePlus())
+                win.set_core(CMMCorePlus(), owns=True)
                 win._mmc.loadSystemConfiguration(path)
                 return
 
@@ -220,7 +237,7 @@ class MainWindow(MicroManagerToolbar):
         # block); don't let that abort the rest of teardown, including
         # atexit-unregister.
         with contextlib.suppress(Exception):
-            self._core_link.cleanup()
+            self._core_link.cleanup(owns=self._owns_core)
         atexit.unregister(self._weak_cleanup)
 
     def _update_max_min(self, *_: Any) -> None:

--- a/src/napari_micromanager/main_window.py
+++ b/src/napari_micromanager/main_window.py
@@ -103,8 +103,8 @@ class MainWindow(MicroManagerToolbar):
 
         self._weak_cleanup = _weak_cleanup
 
-        # Proactive: fires while the viewer is still alive, so signals can
-        # actually be disconnected. `self.destroyed` and `atexit` are fallbacks.
+        # Proactive trigger: fires when the user closes the napari window,
+        # while the viewer is still alive enough to disconnect signals.
         qt_window = getattr(self.viewer.window, "_qt_window", None)
         if qt_window is None:
             warn(
@@ -116,7 +116,8 @@ class MainWindow(MicroManagerToolbar):
         else:
             qt_window.destroyed.connect(_weak_cleanup)
 
-        self.destroyed.connect(_weak_cleanup)
+        # Fallback for process exit without a window close (e.g. script ends
+        # before the user closes the viewer).
         atexit.register(_weak_cleanup)
 
         if config is not None:

--- a/src/napari_micromanager/main_window.py
+++ b/src/napari_micromanager/main_window.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import atexit
 import contextlib
 import logging
+import weakref
 from typing import TYPE_CHECKING, Any
 from warnings import warn
 
@@ -91,9 +92,32 @@ class MainWindow(MicroManagerToolbar):
         if "MinMax" not in getattr(self.viewer.window, "dock_widgets", []):
             self.viewer.window.add_dock_widget(self.minmax, name="MinMax", area="left")
 
-        # queue cleanup
-        self.destroyed.connect(self._cleanup)
-        atexit.register(self._cleanup)
+        # Weakref indirection: a bound-method callback here would make the
+        # registration itself pin `self`, so `destroyed`/`atexit` never fire.
+        self_ref = weakref.ref(self)
+
+        def _weak_cleanup(*_: object) -> None:
+            inst = self_ref()
+            if inst is not None:
+                inst._cleanup()
+
+        self._weak_cleanup = _weak_cleanup
+
+        # Proactive: fires while the viewer is still alive, so signals can
+        # actually be disconnected. `self.destroyed` and `atexit` are fallbacks.
+        qt_window = getattr(self.viewer.window, "_qt_window", None)
+        if qt_window is None:
+            warn(
+                "napari viewer has no `_qt_window`; eager cleanup on window "
+                "close is disabled and device handles may leak until process "
+                "exit.",
+                stacklevel=2,
+            )
+        else:
+            qt_window.destroyed.connect(_weak_cleanup)
+
+        self.destroyed.connect(_weak_cleanup)
+        atexit.register(_weak_cleanup)
 
         if config is not None:
             try:
@@ -181,13 +205,18 @@ class MainWindow(MicroManagerToolbar):
             delattr(core, self._ORIGINAL_LOAD_ATTR)
 
     def _cleanup(self) -> None:
+        if getattr(self, "_cleaned_up", False):
+            return
+        self._cleaned_up = True
         self._unwrap_load_system_configuration(self._mmc)
         for signal, slot in self._connections:
             with contextlib.suppress(TypeError, RuntimeError):
                 signal.disconnect(slot)
+        # Break the self._connections → tuple → bound method → self cycle.
+        self._connections.clear()
         # Clean up temporary files we opened.
         self._core_link.cleanup()
-        atexit.unregister(self._cleanup)  # doesn't raise if not connected
+        atexit.unregister(self._weak_cleanup)
 
     def _update_max_min(self, *_: Any) -> None:
         visible = (x for x in self.viewer.layers.selection if x.visible)

--- a/src/napari_micromanager/main_window.py
+++ b/src/napari_micromanager/main_window.py
@@ -214,8 +214,12 @@ class MainWindow(MicroManagerToolbar):
                 signal.disconnect(slot)
         # Break the self._connections → tuple → bound method → self cycle.
         self._connections.clear()
-        # Clean up temporary files we opened.
-        self._core_link.cleanup()
+        # `_core_link.cleanup()` issues `stopSequenceAcquisition()` to the
+        # camera adapter. If the device is unresponsive this can raise (or
+        # block); don't let that abort the rest of teardown, including
+        # atexit-unregister.
+        with contextlib.suppress(Exception):
+            self._core_link.cleanup()
         atexit.unregister(self._weak_cleanup)
 
     def _update_max_min(self, *_: Any) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def napari_viewer(qapp: Any) -> Iterator[napari.Viewer]:
 
 @pytest.fixture
 def main_window(core: CMMCorePlus, napari_viewer: napari.Viewer) -> MainWindow:
-    win = MainWindow(viewer=napari_viewer)
+    win = MainWindow(viewer=napari_viewer, mmcore=core)
     napari_viewer.window.add_dock_widget(win, name="MainWindow")
     assert core == win._mmc
     return win

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,8 +2,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from pymmcore_plus import CMMCorePlus
 
+from napari_micromanager import get_core
 from napari_micromanager.__main__ import main
 
 
@@ -31,7 +31,7 @@ def test_cli_main(argv: list) -> None:
     mock_show.assert_called_once()
 
     if argv and "test_config" in argv[-1]:
-        assert len(CMMCorePlus.instance().getLoadedDevices()) > 1
+        assert len(get_core().getLoadedDevices()) > 1
 
     # this is to prevent a leaked widget error in the NEXT test
     napari.current_viewer().close()

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -18,7 +18,7 @@ def test_main_window(qtbot: QtBot, core: CMMCorePlus) -> None:
     This test should remain fast.
     """
     viewer = MagicMock()
-    wdg = MainWindow(viewer)
+    wdg = MainWindow(viewer, mmcore=core)
     qtbot.addWidget(wdg)
 
     viewer.layers.events.connect.assert_called_once_with(wdg._update_max_min)

--- a/tests/test_set_core.py
+++ b/tests/test_set_core.py
@@ -22,7 +22,7 @@ CONFIG = str(Path(__file__).parent / "test_config.cfg")
 @pytest.fixture
 def mock_main_window(qtbot: QtBot, core: CMMCorePlus) -> MainWindow:
     viewer = MagicMock()
-    win = MainWindow(viewer)
+    win = MainWindow(viewer, mmcore=core)
     qtbot.addWidget(win)
     return win
 
@@ -99,7 +99,7 @@ def test_set_core_snap_uses_new_core(
         "pymmcore_plus.core._mmcore_plus._instance", weakref.ref(old_core)
     )
 
-    win = MainWindow(viewer=napari_viewer)
+    win = MainWindow(viewer=napari_viewer, mmcore=old_core)
     qtbot.addWidget(win)
     assert win._mmc is old_core
 
@@ -141,7 +141,7 @@ def test_set_core_during_live_mode(
         "pymmcore_plus.core._mmcore_plus._instance", weakref.ref(old_core)
     )
 
-    win = MainWindow(viewer=napari_viewer)
+    win = MainWindow(viewer=napari_viewer, mmcore=old_core)
     qtbot.addWidget(win)
     old_link = win._core_link
 
@@ -244,7 +244,7 @@ def test_auto_detect_py_cfg_swaps_to_unicore(
     )
 
     viewer = MagicMock()
-    win = MainWindow(viewer)
+    win = MainWindow(viewer, mmcore=initial)
     qtbot.addWidget(win)
     assert isinstance(win._mmc, CMMCorePlus)
     assert not isinstance(win._mmc, UniMMCore)
@@ -270,7 +270,7 @@ def test_auto_detect_standard_cfg_swaps_to_mmcore(
     )
 
     viewer = MagicMock()
-    win = MainWindow(viewer)
+    win = MainWindow(viewer, mmcore=initial)
     qtbot.addWidget(win)
     assert isinstance(win._mmc, UniMMCore)
 
@@ -290,7 +290,7 @@ def test_auto_detect_no_swap_when_correct(
     )
 
     viewer = MagicMock()
-    win = MainWindow(viewer)
+    win = MainWindow(viewer, mmcore=initial)
     qtbot.addWidget(win)
     assert isinstance(win._mmc, UniMMCore)
 
@@ -316,7 +316,7 @@ def test_auto_detect_file_not_found(
     )
 
     viewer = MagicMock()
-    win = MainWindow(viewer)
+    win = MainWindow(viewer, mmcore=initial)
     qtbot.addWidget(win)
 
     with pytest.raises(FileNotFoundError):

--- a/tests/test_teardown.py
+++ b/tests/test_teardown.py
@@ -48,8 +48,7 @@ def test_main_window_released_after_viewer_close(
     if surviving is not None:
         # help diagnose: show what's holding it alive
         referrers = [
-            f"{type(r).__name__}: {repr(r)[:160]}"
-            for r in gc.get_referrers(surviving)
+            f"{type(r).__name__}: {repr(r)[:160]}" for r in gc.get_referrers(surviving)
         ]
         raise AssertionError(
             "MainWindow was not released after viewer.close(). Its child "

--- a/tests/test_teardown.py
+++ b/tests/test_teardown.py
@@ -1,0 +1,60 @@
+"""Tests that MainWindow is released when the napari viewer is closed.
+
+Regression test for the device-leak issue where a napari_micromanager
+MainWindow is kept alive by Qt signal connections after the hosting
+napari window is closed, which on real hardware keeps devices (e.g.
+Andor Mosaic3) bound to the dead process and prevents a subsequent
+process from loading the same MM cfg.
+"""
+
+from __future__ import annotations
+
+import gc
+import weakref
+from typing import TYPE_CHECKING, Any
+
+import napari
+
+from napari_micromanager.main_window import MainWindow
+
+if TYPE_CHECKING:
+    from pymmcore_plus import CMMCorePlus
+    from pytestqt.qtbot import QtBot
+
+
+def test_main_window_released_after_viewer_close(
+    qtbot: QtBot, qapp: Any, core: CMMCorePlus
+) -> None:
+    """After viewer.close(), MainWindow must not be kept alive by signals."""
+    viewer = napari.Viewer(show=False)
+    win = MainWindow(viewer=viewer)
+
+    win_ref = weakref.ref(win)
+
+    viewer.close()
+    # pump the Qt event loop so deleteLater()/destroyed can fire — this is what
+    # happens naturally when the user closes the napari window while the GUI
+    # event loop is running.
+    qapp.processEvents()
+    del win
+    del viewer
+    for _ in range(3):
+        gc.collect()
+    qapp.processEvents()
+    for _ in range(3):
+        gc.collect()
+
+    surviving = win_ref()
+    if surviving is not None:
+        # help diagnose: show what's holding it alive
+        referrers = [
+            f"{type(r).__name__}: {repr(r)[:160]}"
+            for r in gc.get_referrers(surviving)
+        ]
+        raise AssertionError(
+            "MainWindow was not released after viewer.close(). Its child "
+            "widgets all hold `_mmc`, so on real hardware this pins the "
+            "CMMCorePlus singleton and the device adapter's exclusive "
+            "handle until the entire Python process exits.\n"
+            f"Referrers ({len(referrers)}):\n  " + "\n  ".join(referrers)
+        )

--- a/tests/test_teardown.py
+++ b/tests/test_teardown.py
@@ -11,15 +11,21 @@ from __future__ import annotations
 
 import gc
 import weakref
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
 
 import napari
 
 from napari_micromanager.main_window import MainWindow
 
 if TYPE_CHECKING:
+    import pytest
     from pymmcore_plus import CMMCorePlus
     from pytestqt.qtbot import QtBot
+
+
+CONFIG = str(Path(__file__).parent / "test_config.cfg")
 
 
 def test_main_window_released_after_viewer_close(
@@ -57,3 +63,65 @@ def test_main_window_released_after_viewer_close(
             "handle until the entire Python process exits.\n"
             f"Referrers ({len(referrers)}):\n  " + "\n  ".join(referrers)
         )
+
+
+def test_cleanup_unloads_devices_when_owned(
+    qtbot: QtBot, napari_viewer: napari.Viewer
+) -> None:
+    """Owned core: _cleanup releases all device adapters."""
+    win = MainWindow(viewer=napari_viewer)
+    qtbot.addWidget(win)
+    win._mmc.loadSystemConfiguration(CONFIG)
+    assert len(win._mmc.getLoadedDevices()) > 1
+
+    win._cleanup()
+
+    # only the built-in "Core" pseudo-device should remain
+    assert len(win._mmc.getLoadedDevices()) <= 1
+
+
+def test_cleanup_preserves_external_core(
+    qtbot: QtBot, napari_viewer: napari.Viewer, core: CMMCorePlus
+) -> None:
+    """External core: _cleanup must not unload devices the caller still uses."""
+    before = len(core.getLoadedDevices())
+    assert before > 1
+
+    win = MainWindow(viewer=napari_viewer, mmcore=core)
+    qtbot.addWidget(win)
+    win._cleanup()
+
+    assert len(core.getLoadedDevices()) == before
+
+
+def test_cleanup_cancels_mda_when_owned(
+    qtbot: QtBot,
+    napari_viewer: napari.Viewer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Owned core: _cleanup cancels any MDA the plugin may have started."""
+    win = MainWindow(viewer=napari_viewer)
+    qtbot.addWidget(win)
+    cancel = MagicMock()
+    monkeypatch.setattr(win._mmc.mda, "cancel", cancel)
+
+    win._cleanup()
+
+    cancel.assert_called_once()
+
+
+def test_cleanup_does_not_cancel_external_mda(
+    qtbot: QtBot,
+    napari_viewer: napari.Viewer,
+    core: CMMCorePlus,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """External core: _cleanup must not cancel an MDA the caller may be running."""
+    win = MainWindow(viewer=napari_viewer, mmcore=core)
+    qtbot.addWidget(win)
+    cancel = MagicMock()
+    monkeypatch.setattr(core.mda, "cancel", cancel)
+
+    win._cleanup()
+
+    cancel.assert_not_called()


### PR DESCRIPTION
## Summary

Closing the napari window didn't release the `CMMCorePlus` singleton or the
MainWindow widget. On real hardware this leaks device handles: a subsequent
Python process that tries to load the same MM cfg fails (e.g. "No Mosaic3
devices found") until the original process is killed. Reported against an
Andor Mosaic3 but applies to any adapter that takes an exclusive handle.

## Problem

`MainWindow.__init__` creates four bound-method connections that pin `self`
and, transitively, every child widget that holds `_mmc`:

- `self.destroyed.connect(self._cleanup)` — classic self-cycle: the signal
  holds the bound method, which holds `self`, which owns the signal.
  `destroyed` therefore never fires and `_cleanup` never runs.
- `atexit.register(self._cleanup)` — same cycle via atexit.
- Three `viewer.*.events.connect(self._update_max_min)` entries — only
  disconnected inside `_cleanup`, i.e. never.

After #368 (`CMMCorePlus._instance` as `weakref.ref`) the remaining strong
references were all inside napari-micromanager, so the leak is fixable here.

A secondary leak: accessing `viewer.window._qt_viewer.console` from
`MicroManagerToolbar.__init__` triggers `napari_console._capture()`, which
walks up the call stack to the first non-napari frame and pushes its whole
namespace — including the `self` local — into the IPython user_ns. That
reference persists for the process lifetime.

## Solution

**`main_window.py`**
- Register a weakref-based closure (`_weak_cleanup`) instead of the bound
  method. Neither `self.destroyed`, `atexit`, nor the new proactive hook
  pin `self` anymore.
- Connect `viewer.window._qt_window.destroyed` as the primary cleanup trigger.
  It fires while the viewer is still alive, which is the only time signal
  disconnection actually works. `self.destroyed` + `atexit` remain as
  fallbacks. If napari ever drops `_qt_window`, we `warn()` instead of
  silently regressing.
- `_cleanup` is now idempotent, and `self._connections.clear()` breaks the
  remaining `list → tuple → bound method → self` cycle after disconnects.
- Wrap `self._core_link.cleanup()` in `contextlib.suppress(Exception)` so a
  misbehaving device can't abort the rest of teardown.

**`_gui_objects/_toolbar.py`**
- Add `NAPARI_EMBED = True` at module level — napari-console's documented
  opt-out sentinel for its frame-capture behavior.

## Risk: unresponsive devices on teardown

Unlike today, `_cleanup()` now actually runs on window close. That means
`_core_link.cleanup()` → `mmc.stopSequenceAcquisition()` will now fire
against the camera adapter while the viewer is closing. If live-mode is
running on a wedged device, that C-level call can raise or block — the
`suppress(Exception)` handles the raise case, but a hang would appear as
a zombie process (same symptom as the bug this PR fixes, just for a
different reason). Net effect is still strictly better: before this PR
the process *always* lingered; after this PR it only lingers on a wedged
device.

The long-term mitigation belongs at the pymmcore-plus boundary, not here —
see pymmcore-plus/pymmcore-plus#614, which proposes per-device timeouts on
the wait calls that sit underneath `stopSequenceAcquisition`. If that
lands, the stop path can fail-fast instead of hanging. Not a dependency
for this PR.

## Test plan

- [x] New regression test: `tests/test_teardown.py::test_main_window_released_after_viewer_close`.
  Creates a viewer + MainWindow, closes, pumps the Qt event loop, asserts
  that a weakref to MainWindow resolves to `None`. Fails cleanly with a
  `gc.get_referrers` dump of the 5 surviving bound-method referrers before
  the fix; passes after.
- [x] Full suite: 61 passed, 1 skipped, 1 pre-existing failure on main
  (`test_set_core.py::test_auto_detect_standard_cfg_swaps_to_mmcore`, fails
  on bare upstream too — unrelated to this PR).
- [x] On-hardware verification (Mosaic3 cfg, Shell 1 / Shell 3 sequence from
  the original report) — confirms the exclusive handle is actually released.
  Not runnable in CI.

## Notes on scope

- This fix only touches napari-micromanager cycles. The lingering
  `setExposure` bound method and `mmcore` key in the IPython user_ns live
  in pymmcore-widgets and napari-console respectively and don't block the
  main leak from being fixed here.
- Reusing `mmc` from an external notebook across an open/close cycle still
  works: `_cleanup` only disconnects our own listeners; it doesn't call
  `unloadAllDevices()` or otherwise mutate core state.