### PR TITLE
fix: avoid camera-buffer race in _image_snapped on first MDA event

### DIFF
--- a/src/napari_micromanager/_core_link.py
+++ b/src/napari_micromanager/_core_link.py
@@ -85,14 +85,18 @@ class CoreViewerLink(QObject):
             handler._update_viewer_dims(handler._viewer_updates.popleft())
 
     def _image_snapped(self) -> None:
-        # Query the runner directly: _mda_handler._mda_running is set on the
-        # main thread inside _on_mda_started, which on the very first MDA
-        # event can run *after* the worker thread has already called
-        # snapImage(). In that race window this handler would consume the
-        # snap buffer before the engine's getImage(), causing the engine to
-        # raise "Camera image buffer read failed". mmc.mda.is_running()
-        # reflects the runner state immediately, without a queued-signal lag.
-        if not self._mmc.mda.is_running():
+        # Two layers gate the preview update during MDA:
+        # - mmc.mda.is_running() is set synchronously by the runner and
+        #   covers the start race where _on_mda_started's queued main-thread
+        #   handler hasn't yet set _mda_running True.
+        # - _mda_handler._mda_running is the latched flag cleared on the
+        #   main thread by _on_mda_finished; it covers the symmetric end
+        #   race where the runner has already cleared _running and emitted
+        #   sequenceFinished but a trailing imageSnapped slot is still
+        #   pending.
+        if not (
+            self._mmc.mda.is_running() or self._mda_handler._mda_running
+        ):
             self._update_viewer(self._mmc.getImage())
 
     def _start_live(self) -> None:

--- a/src/napari_micromanager/_core_link.py
+++ b/src/napari_micromanager/_core_link.py
@@ -85,8 +85,14 @@ class CoreViewerLink(QObject):
             handler._update_viewer_dims(handler._viewer_updates.popleft())
 
     def _image_snapped(self) -> None:
-        # If we are in the middle of an MDA, don't update the preview viewer.
-        if not self._mda_handler._mda_running:
+        # Query the runner directly: _mda_handler._mda_running is set on the
+        # main thread inside _on_mda_started, which on the very first MDA
+        # event can run *after* the worker thread has already called
+        # snapImage(). In that race window this handler would consume the
+        # snap buffer before the engine's getImage(), causing the engine to
+        # raise "Camera image buffer read failed". mmc.mda.is_running()
+        # reflects the runner state immediately, without a queued-signal lag.
+        if not self._mmc.mda.is_running():
             self._update_viewer(self._mmc.getImage())
 
     def _start_live(self) -> None:

--- a/src/napari_micromanager/_core_link.py
+++ b/src/napari_micromanager/_core_link.py
@@ -94,9 +94,7 @@ class CoreViewerLink(QObject):
         #   race where the runner has already cleared _running and emitted
         #   sequenceFinished but a trailing imageSnapped slot is still
         #   pending.
-        if not (
-            self._mmc.mda.is_running() or self._mda_handler._mda_running
-        ):
+        if not (self._mmc.mda.is_running() or self._mda_handler._mda_running):
             self._update_viewer(self._mmc.getImage())
 
     def _start_live(self) -> None:

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+import pytest
 import useq
 
 from napari_micromanager.main_window import MainWindow
@@ -46,3 +47,31 @@ def test_preview_while_mda(main_window: MainWindow, qtbot: QtBot):
 
     layers = [layer.name for layer in viewer.layers]
     assert "preview" not in layers
+
+
+@pytest.mark.parametrize(
+    "is_running, mda_running",
+    [(True, False), (False, True)],
+    ids=["runner_started_latch_unset", "runner_exited_latch_set"],
+)
+def test_image_snapped_gate_closed_during_mda_signal_window(
+    main_window: MainWindow,
+    monkeypatch: pytest.MonkeyPatch,
+    is_running: bool,
+    mda_running: bool,
+):
+    """The preview gate must stay closed in both queued-signal race
+    windows around an MDA: when the runner has started but the queued
+    ``@ensure_main_thread`` ``_on_mda_started`` slot hasn't latched
+    ``_mda_running`` yet, and when the runner has already exited
+    (also after a mid-MDA cancel) but ``_on_mda_finished`` hasn't
+    cleared the latch on the main thread. Either gate alone is
+    insufficient; both must be checked.
+    """
+    core_link = main_window._core_link
+    monkeypatch.setattr(main_window._mmc.mda, "is_running", lambda: is_running)
+    monkeypatch.setattr(core_link._mda_handler, "_mda_running", mda_running)
+
+    with patch.object(core_link, "_update_viewer") as mocked:
+        core_link._image_snapped()
+    mocked.assert_not_called()


### PR DESCRIPTION
## Summary

`CoreViewerLink._image_snapped` gates its preview-update so the snap buffer isn't consumed during an MDA. The previous gate (`not self._mda_handler._mda_running`) had a **start-of-MDA race**: `_mda_running` is set inside `_on_mda_started`, which is `@ensure_main_thread`-queued, so on the very first MDA event the worker thread can call `mmc.snapImage()` before that queued handler fires. With Qt-backed `mmc.events`, the `imageSnapped` slot is also queued main-thread; if the main thread processes the queued `imageSnapped` before the queued `_on_mda_started`, the handler reads the snap buffer first and the engine's `exec_single_event` raises `RuntimeError: Camera image buffer read failed.`.

Querying the runner directly (`self._mmc.mda.is_running()`) closes the start race — but on its own opens the **symmetric end race**: `runner._running` is set False on the worker thread *before* `sequenceFinished` is queued (see `pymmcore_plus/mda/_runner.py:_finish_run`). The last event's queued `imageSnapped` slot, processed on the main thread after the runner exits, will see `is_running() == False` and create a stray preview layer post-MDA. This regression is caught by the existing `test_preview_while_mda[CMMCorePlus]` test.

This PR gates on **both** conditions — closed if `is_running()` OR `_mda_running`:

- `is_running()` covers the start race (synchronous runner state).
- `_mda_running` is the latched flag cleared only inside `_on_mda_finished`; it covers the end race by staying True until any trailing queued `imageSnapped` slots have drained.

Generator MDAs are unaffected: their preview path goes through `_NapariMDAHandler._on_mda_frame` (on `frameReady`), not `_image_snapped` — covered by the existing `test_generator_mda_does_not_crash`.

## Reproduction (demo camera, no hardware)

**Start race** — place the system in the exact race state (runner up, stale main-thread flag still `False`) and call `_image_snapped` directly, counting `mmc.getImage()` calls:

|                       | Scenario A: race state (runner up, stale flag False) | Scenario B: idle (no MDA, normal preview) |
| --------------------- | ---------------------------------------------------- | ----------------------------------------- |
| **Before** (main)     | `getImage` called → ``Camera image buffer read failed`` (or ``Issue snapImage before getImage`` on the demo camera, same family) | `getImage` + preview update; works |
| **After** (this PR)   | `getImage` **not** called; engine's read is safe     | `getImage` + preview update; works |

**End race** — `test_preview_while_mda[CMMCorePlus]` runs an MDA and asserts no `preview` layer exists afterwards. With `is_running()` alone the trailing queued `imageSnapped` opens the gate post-MDA; with the combined `is_running() or _mda_running` the latch keeps it closed until `_on_mda_finished` runs on the main thread.

## Test plan

- [x] Demo MM camera reproduction of the start race
- [x] `test_preview_while_mda[CMMCorePlus]` and `[UniMMCore]` pass locally on macOS (PyQt6)
- [x] New parametrized regression test `test_image_snapped_gate_closed_during_mda_signal_window` pins both races: each gate alone fails exactly one parametric case (`runner_started_latch_unset` on `main`, `runner_exited_latch_set` on the `is_running`-only variant); only the combined gate passes both.
- [x] No regression in normal user-snap preview (idle Scenario B above)
- [x] No regression in `test_main_window_mda`, `test_saving_mda`, `test_script_initiated_mda`, `test_generator_mda_does_not_crash`
- [x] **Manual GUI test on demo config (macOS, PyQt6):**
  - Loaded `MMConfig_demo.cfg` and snapped — `preview` layer populated as expected.
  - Ran a 5-frame FITC MDA from the MultiDWidget — frames went to the `Exp_…` zarr layer, `preview` was *not* updated during the run, and **no stray `preview` layer appeared after the MDA finished**.
  - Started a multi-frame MDA and cancelled mid-run — clean stop, no spurious post-MDA `preview` layer, captured frames preserved in the `Exp_…` layer.
  - Live mode → stop → MDA → MDA finishes: live/snap path resumes normally after the run.
- [ ] CI passes — green on all matrix entries except `windows-latest py3.13 PySide6 highest`, which fails on `tests/test_layer_scale.py` with `SystemError` from `disconnect()` introduced in `pyside6==6.11.1` (`_NapariMDAHandler._cleanup` only suppresses `TypeError, RuntimeError`). This pre-dates this PR — `main` was last tested on PySide6 6.11.0 and will fail the same way on its next CI run. Tracked separately; **not** caused by this change.
