### PR TITLE
build: relax zarr pin to >=2.18 (allow zarr 3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "superqt >=0.5.1",
     "tifffile >=2023.2.3",
     "useq-schema >=0.4.1",
-    "zarr >=2.18,<3",
+    "zarr >=2.18",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
Relax `zarr` from `>=2.18,<3` to `>=2.18`, allowing zarr 3.

## Why
The `<3` bound was added in 30cb1be (#370, "refactor: update to uv, broad
repo update") — a large modernization sweep with no zarr-3-specific
rationale; before it the dependency was unconstrained. The pin forces
downstream projects that need `zarr>=3` to install via a dependency-override
workaround.

napari-micromanager's whole zarr surface is in `_mda_handler.py` —
`zarr.open(shape=, dtype=, chunks=)`, per-frame indexed writes,
`z.store.close()`, and wrapping the array as a napari layer. I tested each
against zarr 3.1.4 and they all work unchanged; `napari >=0.5.0` (already
the minimum) accepts zarr-3 arrays as layer data.

## Question
@tlambert03 — was the `<3` bound in #370 deliberate (a known zarr-3
incompatibility)?